### PR TITLE
Include record timestamp with offset in commit response

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.toList;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.channel.events.Event;
+import io.tabular.iceberg.connect.data.Offset;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
@@ -76,9 +77,9 @@ public abstract class Channel {
     send(ImmutableList.of(event), ImmutableMap.of());
   }
 
-  protected void send(List<Event> events, Map<TopicPartition, Long> sourceOffsets) {
+  protected void send(List<Event> events, Map<TopicPartition, Offset> sourceOffsets) {
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>();
-    sourceOffsets.forEach((k, v) -> offsetsToCommit.put(k, new OffsetAndMetadata(v)));
+    sourceOffsets.forEach((k, v) -> offsetsToCommit.put(k, new OffsetAndMetadata(v.getOffset())));
 
     List<ProducerRecord<String, byte[]>> recordList =
         events.stream()

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/TopicPartitionOffset.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/TopicPartitionOffset.java
@@ -28,6 +28,7 @@ public class TopicPartitionOffset implements Element {
   private String topic;
   private Integer partition;
   private Long offset;
+  private Long timestamp;
   private Schema avroSchema;
 
   public static final Schema AVRO_SCHEMA =
@@ -50,16 +51,23 @@ public class TopicPartitionOffset implements Element {
           .nullable()
           .longType()
           .noDefault()
+          .name("timestamp")
+          .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+          .type()
+          .nullable()
+          .longType()
+          .noDefault()
           .endRecord();
 
   public TopicPartitionOffset(Schema avroSchema) {
     this.avroSchema = avroSchema;
   }
 
-  public TopicPartitionOffset(String topic, int partition, Long offset) {
+  public TopicPartitionOffset(String topic, int partition, Long offset, Long timestamp) {
     this.topic = topic;
     this.partition = partition;
     this.offset = offset;
+    this.timestamp = timestamp;
     this.avroSchema = AVRO_SCHEMA;
   }
 
@@ -73,6 +81,10 @@ public class TopicPartitionOffset implements Element {
 
   public Long getOffset() {
     return offset;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
   }
 
   @Override
@@ -92,6 +104,9 @@ public class TopicPartitionOffset implements Element {
       case 2:
         this.offset = (Long) v;
         return;
+      case 3:
+        this.timestamp = (Long) v;
+        return;
       default:
         // ignore the object, it must be from a newer version of the format
     }
@@ -106,6 +121,8 @@ public class TopicPartitionOffset implements Element {
         return partition;
       case 2:
         return offset;
+      case 3:
+        return timestamp;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + i);
     }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -38,9 +38,9 @@ public class IcebergWriter implements Closeable {
   private final Table table;
   private final TableIdentifier tableIdentifier;
   private final IcebergSinkConfig config;
-  private RecordConverter recordConverter;
-  private TaskWriter<Record> writer;
-  private Map<TopicPartition, Long> offsets;
+  private final RecordConverter recordConverter;
+  private final TaskWriter<Record> writer;
+  private final Map<TopicPartition, Offset> offsets;
 
   public IcebergWriter(Catalog catalog, String tableName, IcebergSinkConfig config) {
     this.tableIdentifier = TableIdentifier.parse(tableName);
@@ -55,7 +55,8 @@ public class IcebergWriter implements Closeable {
     // the consumer stores the offsets that corresponds to the next record to consume,
     // so increment the record offset by one
     offsets.put(
-        new TopicPartition(record.topic(), record.kafkaPartition()), record.kafkaOffset() + 1);
+        new TopicPartition(record.topic(), record.kafkaPartition()),
+        new Offset(record.kafkaOffset() + 1, record.timestamp()));
     try {
       // TODO: config to handle tombstones instead of always ignoring?
       if (record.value() != null) {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Offset.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Offset.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.data;
+
+import java.util.Objects;
+
+public class Offset implements Comparable<Offset> {
+
+  public static final Offset NULL_OFFSET = new Offset(null, null);
+
+  private final Long offset;
+  private final Long timestamp;
+
+  public Offset(Long offset, Long timestamp) {
+    this.offset = offset;
+    this.timestamp = timestamp;
+  }
+
+  public Long getOffset() {
+    return offset;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public int compareTo(Offset other) {
+    if (Objects.equals(this.offset, other.offset)) {
+      return 0;
+    }
+    if (this.offset == null || (other.offset != null && other.offset > this.offset)) {
+      return -1;
+    }
+    return 1;
+  }
+}

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/WriterResult.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/WriterResult.java
@@ -32,14 +32,14 @@ public class WriterResult {
   private final List<DataFile> dataFiles;
   private final List<DeleteFile> deleteFiles;
   private final StructType partitionStruct;
-  private final Map<TopicPartition, Long> offsets;
+  private final Map<TopicPartition, Offset> offsets;
 
   public WriterResult(
       TableIdentifier tableIdentifier,
       List<DataFile> dataFiles,
       List<DeleteFile> deleteFiles,
       StructType partitionStruct,
-      Map<TopicPartition, Long> offsets) {
+      Map<TopicPartition, Offset> offsets) {
     this.tableIdentifier = tableIdentifier;
     this.dataFiles = dataFiles;
     this.deleteFiles = deleteFiles;
@@ -63,7 +63,7 @@ public class WriterResult {
     return partitionStruct;
   }
 
-  public Map<TopicPartition, Long> getOffsets() {
+  public Map<TopicPartition, Offset> getOffsets() {
     return offsets;
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -98,7 +98,7 @@ public class CoordinatorTest extends ChannelTestBase {
         new Event(
             EventType.COMMIT_READY,
             new CommitReadyPayload(
-                commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L))));
+                commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, 1L))));
     bytes = AvroEncoderUtil.encode(commitReady, commitReady.getSchema());
     consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
 

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -30,6 +30,7 @@ import io.tabular.iceberg.connect.channel.events.CommitResponsePayload;
 import io.tabular.iceberg.connect.channel.events.Event;
 import io.tabular.iceberg.connect.channel.events.EventType;
 import io.tabular.iceberg.connect.data.IcebergWriter;
+import io.tabular.iceberg.connect.data.Offset;
 import io.tabular.iceberg.connect.data.WriterResult;
 import java.io.IOException;
 import java.util.Map;
@@ -77,7 +78,7 @@ public class WorkerTest extends ChannelTestBase {
             ImmutableList.of(createDataFile()),
             ImmutableList.of(),
             StructType.of(),
-            ImmutableMap.of(new TopicPartition(SRC_TOPIC_NAME, 0), 0L));
+            ImmutableMap.of(new TopicPartition(SRC_TOPIC_NAME, 0), new Offset(0L, 0L)));
     IcebergWriter writer = mock(IcebergWriter.class);
     when(writer.complete()).thenReturn(writeResult);
 

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/events/EventTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/events/EventTest.java
@@ -78,8 +78,8 @@ public class EventTest {
             new CommitReadyPayload(
                 commitId,
                 ImmutableList.of(
-                    new TopicPartitionOffset("topic", 1, 1L),
-                    new TopicPartitionOffset("topic", 2, null))));
+                    new TopicPartitionOffset("topic", 1, 1L, 1L),
+                    new TopicPartitionOffset("topic", 2, null, null))));
 
     byte[] data = AvroEncoderUtil.encode(event, event.getSchema());
     Event result = AvroEncoderUtil.decode(data);

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/OffsetTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/OffsetTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class OffsetTest {
+
+  @Test
+  public void testOffsetEquals() {
+    assertEquals(0, new Offset(null, null).compareTo(new Offset(null, null)));
+    assertEquals(0, new Offset(1L, null).compareTo(new Offset(1L, null)));
+  }
+
+  @Test
+  public void testOffsetLessThan() {
+    assertEquals(-1, new Offset(null, null).compareTo(new Offset(1L, null)));
+    assertEquals(-1, new Offset(1L, null).compareTo(new Offset(2L, null)));
+  }
+
+  @Test
+  public void testOffsetGreaterThan() {
+    assertEquals(1, new Offset(1L, null).compareTo(new Offset(null, null)));
+    assertEquals(1, new Offset(2L, null).compareTo(new Offset(1L, null)));
+  }
+}


### PR DESCRIPTION
This PR adds the last record timestamp to the worker commit response so it is passed along with the offset per topic partition.