### PR TITLE
VTTS snapshot property and commit complete event

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -206,9 +206,10 @@ public class Coordinator extends Channel {
     commitConsumerOffsets();
     commitBuffer.clear();
     readyBuffer.clear();
+    UUID commitId = currentCommitId;
     currentCommitId = null;
 
-    Event event = new Event(EventType.COMMIT_END, new CommitEndPayload(currentCommitId, vtts));
+    Event event = new Event(EventType.COMMIT_END, new CommitEndPayload(commitId, vtts));
     send(event);
 
     LOG.info(

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/CommitCompletePayload.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/CommitCompletePayload.java
@@ -27,8 +27,6 @@ import org.apache.avro.SchemaBuilder;
 public class CommitCompletePayload implements Payload {
 
   private UUID commitId;
-  private TableName tableName;
-  private Long snapshotId;
   private Long vtts;
   private Schema avroSchema;
 
@@ -36,10 +34,8 @@ public class CommitCompletePayload implements Payload {
     this.avroSchema = avroSchema;
   }
 
-  public CommitCompletePayload(UUID commitId, TableName tableName, Long snapshotId, Long vtts) {
+  public CommitCompletePayload(UUID commitId, Long vtts) {
     this.commitId = commitId;
-    this.tableName = tableName;
-    this.snapshotId = snapshotId;
     this.vtts = vtts;
 
     this.avroSchema =
@@ -49,16 +45,6 @@ public class CommitCompletePayload implements Payload {
             .name("commitId")
             .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
             .type(UUID_SCHEMA)
-            .noDefault()
-            .name("tableName")
-            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
-            .type(TableName.AVRO_SCHEMA)
-            .noDefault()
-            .name("snapshotId")
-            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
-            .type()
-            .nullable()
-            .longType()
             .noDefault()
             .name("vtts")
             .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
@@ -71,14 +57,6 @@ public class CommitCompletePayload implements Payload {
 
   public UUID getCommitId() {
     return commitId;
-  }
-
-  public TableName getTableName() {
-    return tableName;
-  }
-
-  public Long getSnapshotId() {
-    return snapshotId;
   }
 
   public Long getVtts() {
@@ -98,12 +76,6 @@ public class CommitCompletePayload implements Payload {
         this.commitId = (UUID) v;
         return;
       case 1:
-        this.tableName = (TableName) v;
-        return;
-      case 2:
-        this.snapshotId = (Long) v;
-        return;
-      case 3:
         this.vtts = (Long) v;
         return;
       default:
@@ -117,10 +89,6 @@ public class CommitCompletePayload implements Payload {
       case 0:
         return commitId;
       case 1:
-        return tableName;
-      case 2:
-        return snapshotId;
-      case 3:
         return vtts;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + i);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/CommitCompletePayload.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/CommitCompletePayload.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.channel.events;
+
+import static org.apache.iceberg.avro.AvroSchemaUtil.FIELD_ID_PROP;
+
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+public class CommitCompletePayload implements Payload {
+
+  private UUID commitId;
+  private TableName tableName;
+  private Long snapshotId;
+  private Long vtts;
+  private Schema avroSchema;
+
+  public CommitCompletePayload(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public CommitCompletePayload(UUID commitId, TableName tableName, Long snapshotId, Long vtts) {
+    this.commitId = commitId;
+    this.tableName = tableName;
+    this.snapshotId = snapshotId;
+    this.vtts = vtts;
+
+    this.avroSchema =
+        SchemaBuilder.builder()
+            .record(getClass().getName())
+            .fields()
+            .name("commitId")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type(UUID_SCHEMA)
+            .noDefault()
+            .name("tableName")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type(TableName.AVRO_SCHEMA)
+            .noDefault()
+            .name("snapshotId")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type()
+            .nullable()
+            .longType()
+            .noDefault()
+            .name("vtts")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type()
+            .nullable()
+            .longType()
+            .noDefault()
+            .endRecord();
+  }
+
+  public UUID getCommitId() {
+    return commitId;
+  }
+
+  public TableName getTableName() {
+    return tableName;
+  }
+
+  public Long getSnapshotId() {
+    return snapshotId;
+  }
+
+  public Long getVtts() {
+    return vtts;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.commitId = (UUID) v;
+        return;
+      case 1:
+        this.tableName = (TableName) v;
+        return;
+      case 2:
+        this.snapshotId = (Long) v;
+        return;
+      case 3:
+        this.vtts = (Long) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return commitId;
+      case 1:
+        return tableName;
+      case 2:
+        return snapshotId;
+      case 3:
+        return vtts;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/CommitEndPayload.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/CommitEndPayload.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.channel.events;
+
+import static org.apache.iceberg.avro.AvroSchemaUtil.FIELD_ID_PROP;
+
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+public class CommitEndPayload implements Payload {
+
+  private UUID commitId;
+  private Long vtts;
+  private Schema avroSchema;
+
+  public CommitEndPayload(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public CommitEndPayload(UUID commitId, Long vtts) {
+    this.commitId = commitId;
+    this.vtts = vtts;
+
+    this.avroSchema =
+        SchemaBuilder.builder()
+            .record(getClass().getName())
+            .fields()
+            .name("commitId")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type(UUID_SCHEMA)
+            .noDefault()
+            .name("vtts")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type()
+            .nullable()
+            .longType()
+            .noDefault()
+            .endRecord();
+  }
+
+  public UUID getCommitId() {
+    return commitId;
+  }
+
+  public Long getVtts() {
+    return vtts;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.commitId = (UUID) v;
+        return;
+      case 1:
+        this.vtts = (Long) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return commitId;
+      case 1:
+        return vtts;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/CommitTablePayload.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/CommitTablePayload.java
@@ -24,18 +24,22 @@ import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 
-public class CommitEndPayload implements Payload {
+public class CommitTablePayload implements Payload {
 
   private UUID commitId;
+  private TableName tableName;
+  private Long snapshotId;
   private Long vtts;
   private Schema avroSchema;
 
-  public CommitEndPayload(Schema avroSchema) {
+  public CommitTablePayload(Schema avroSchema) {
     this.avroSchema = avroSchema;
   }
 
-  public CommitEndPayload(UUID commitId, Long vtts) {
+  public CommitTablePayload(UUID commitId, TableName tableName, Long snapshotId, Long vtts) {
     this.commitId = commitId;
+    this.tableName = tableName;
+    this.snapshotId = snapshotId;
     this.vtts = vtts;
 
     this.avroSchema =
@@ -45,6 +49,16 @@ public class CommitEndPayload implements Payload {
             .name("commitId")
             .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
             .type(UUID_SCHEMA)
+            .noDefault()
+            .name("tableName")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type(TableName.AVRO_SCHEMA)
+            .noDefault()
+            .name("snapshotId")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type()
+            .nullable()
+            .longType()
             .noDefault()
             .name("vtts")
             .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
@@ -57,6 +71,14 @@ public class CommitEndPayload implements Payload {
 
   public UUID getCommitId() {
     return commitId;
+  }
+
+  public TableName getTableName() {
+    return tableName;
+  }
+
+  public Long getSnapshotId() {
+    return snapshotId;
   }
 
   public Long getVtts() {
@@ -76,6 +98,12 @@ public class CommitEndPayload implements Payload {
         this.commitId = (UUID) v;
         return;
       case 1:
+        this.tableName = (TableName) v;
+        return;
+      case 2:
+        this.snapshotId = (Long) v;
+        return;
+      case 3:
         this.vtts = (Long) v;
         return;
       default:
@@ -89,6 +117,10 @@ public class CommitEndPayload implements Payload {
       case 0:
         return commitId;
       case 1:
+        return tableName;
+      case 2:
+        return snapshotId;
+      case 3:
         return vtts;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + i);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/EventType.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/EventType.java
@@ -21,7 +21,8 @@ package io.tabular.iceberg.connect.channel.events;
 public enum EventType {
   COMMIT_REQUEST(0),
   COMMIT_RESPONSE(1),
-  COMMIT_READY(2);
+  COMMIT_READY(2),
+  COMMIT_COMPLETE(3);
 
   private final int id;
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/EventType.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/EventType.java
@@ -22,7 +22,8 @@ public enum EventType {
   COMMIT_REQUEST(0),
   COMMIT_RESPONSE(1),
   COMMIT_READY(2),
-  COMMIT_COMPLETE(3);
+  COMMIT_COMPLETE(3),
+  COMMIT_END(4);
 
   private final int id;
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/EventType.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/events/EventType.java
@@ -22,8 +22,8 @@ public enum EventType {
   COMMIT_REQUEST(0),
   COMMIT_RESPONSE(1),
   COMMIT_READY(2),
-  COMMIT_COMPLETE(3),
-  COMMIT_END(4);
+  COMMIT_TABLE(3),
+  COMMIT_COMPLETE(4);
 
   private final int id;
 

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -60,10 +61,14 @@ public class ChannelTestBase {
   @BeforeEach
   @SuppressWarnings("deprecation")
   public void setup() {
+    Snapshot snapshot = mock(Snapshot.class);
+    when(snapshot.snapshotId()).thenReturn(1L);
+
     appendOp = mock(AppendFiles.class);
     deltaOp = mock(RowDelta.class);
 
     table = mock(Table.class);
+    when(table.currentSnapshot()).thenReturn(snapshot);
     when(table.newAppend()).thenReturn(appendOp);
     when(table.newRowDelta()).thenReturn(deltaOp);
 

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -27,10 +27,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.channel.events.CommitCompletePayload;
-import io.tabular.iceberg.connect.channel.events.CommitEndPayload;
 import io.tabular.iceberg.connect.channel.events.CommitReadyPayload;
 import io.tabular.iceberg.connect.channel.events.CommitRequestPayload;
 import io.tabular.iceberg.connect.channel.events.CommitResponsePayload;
+import io.tabular.iceberg.connect.channel.events.CommitTablePayload;
 import io.tabular.iceberg.connect.channel.events.Event;
 import io.tabular.iceberg.connect.channel.events.EventType;
 import io.tabular.iceberg.connect.channel.events.TableName;
@@ -113,19 +113,19 @@ public class CoordinatorTest extends ChannelTestBase {
     assertEquals(3, producer.history().size());
 
     bytes = producer.history().get(1).value();
+    Event commitTable = AvroEncoderUtil.decode(bytes);
+    assertEquals(EventType.COMMIT_TABLE, commitTable.getType());
+    CommitTablePayload commitTablePayload = (CommitTablePayload) commitTable.getPayload();
+    assertEquals(commitId, commitTablePayload.getCommitId());
+    assertEquals("db.tbl", commitTablePayload.getTableName().toIdentifier().toString());
+    assertEquals(ts, commitTablePayload.getVtts());
+
+    bytes = producer.history().get(2).value();
     Event commitComplete = AvroEncoderUtil.decode(bytes);
     assertEquals(EventType.COMMIT_COMPLETE, commitComplete.getType());
     CommitCompletePayload commitCompletePayload =
         (CommitCompletePayload) commitComplete.getPayload();
     assertEquals(commitId, commitCompletePayload.getCommitId());
-    assertEquals("db.tbl", commitCompletePayload.getTableName().toIdentifier().toString());
     assertEquals(ts, commitCompletePayload.getVtts());
-
-    bytes = producer.history().get(2).value();
-    Event commitEnd = AvroEncoderUtil.decode(bytes);
-    assertEquals(EventType.COMMIT_END, commitEnd.getType());
-    CommitEndPayload commitEndPayload = (CommitEndPayload) commitEnd.getPayload();
-    assertEquals(commitId, commitEndPayload.getCommitId());
-    assertEquals(ts, commitEndPayload.getVtts());
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/events/EventTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/events/EventTest.java
@@ -94,19 +94,18 @@ public class EventTest {
   }
 
   @Test
-  public void testCommitCompleteSerialization() throws Exception {
+  public void testCommitTableSerialization() throws Exception {
     UUID commitId = UUID.randomUUID();
     Event event =
         new Event(
-            EventType.COMMIT_COMPLETE,
-            new CommitCompletePayload(
-                commitId, new TableName(ImmutableList.of("db"), "tbl"), 1L, 2L));
+            EventType.COMMIT_TABLE,
+            new CommitTablePayload(commitId, new TableName(ImmutableList.of("db"), "tbl"), 1L, 2L));
 
     byte[] data = AvroEncoderUtil.encode(event, event.getSchema());
     Event result = AvroEncoderUtil.decode(data);
 
     assertEquals(event.getType(), result.getType());
-    CommitCompletePayload payload = (CommitCompletePayload) result.getPayload();
+    CommitTablePayload payload = (CommitTablePayload) result.getPayload();
     assertEquals(commitId, payload.getCommitId());
     assertEquals(TableIdentifier.parse("db.tbl"), payload.getTableName().toIdentifier());
     assertEquals(1L, payload.getSnapshotId());
@@ -114,15 +113,15 @@ public class EventTest {
   }
 
   @Test
-  public void testCommitEndSerialization() throws Exception {
+  public void testCommitCompleteSerialization() throws Exception {
     UUID commitId = UUID.randomUUID();
-    Event event = new Event(EventType.COMMIT_END, new CommitEndPayload(commitId, 2L));
+    Event event = new Event(EventType.COMMIT_COMPLETE, new CommitCompletePayload(commitId, 2L));
 
     byte[] data = AvroEncoderUtil.encode(event, event.getSchema());
     Event result = AvroEncoderUtil.decode(data);
 
     assertEquals(event.getType(), result.getType());
-    CommitEndPayload payload = (CommitEndPayload) result.getPayload();
+    CommitCompletePayload payload = (CommitCompletePayload) result.getPayload();
     assertEquals(commitId, payload.getCommitId());
     assertEquals(2L, payload.getVtts());
   }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/events/EventTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/events/EventTest.java
@@ -112,4 +112,18 @@ public class EventTest {
     assertEquals(1L, payload.getSnapshotId());
     assertEquals(2L, payload.getVtts());
   }
+
+  @Test
+  public void testCommitEndSerialization() throws Exception {
+    UUID commitId = UUID.randomUUID();
+    Event event = new Event(EventType.COMMIT_END, new CommitEndPayload(commitId, 2L));
+
+    byte[] data = AvroEncoderUtil.encode(event, event.getSchema());
+    Event result = AvroEncoderUtil.decode(data);
+
+    assertEquals(event.getType(), result.getType());
+    CommitEndPayload payload = (CommitEndPayload) result.getPayload();
+    assertEquals(commitId, payload.getCommitId());
+    assertEquals(2L, payload.getVtts());
+  }
 }


### PR DESCRIPTION
This PR adds a valid-through timestamp snapshot property, and also sends an event to the control topic for each table commit, and after all commits are completed (for multi-table cases).