### PR TITLE
Prevent concurrent Kafka transactions for a producer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ subprojects {
   apply plugin: "maven-publish"
 
   group "io.tabular.connect"
-  version "0.3.3-SNAPSHOT"
+  version "0.3.3"
 
   repositories {
     mavenCentral()


### PR DESCRIPTION
This PR adds a synchronized block when using transactions to send to Kafka, as only one transaction for a producer can be active at a time.