### PR TITLE
Default to a single control topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.dynamic.enabled           | Set to `true` to route to a table specified in `routeField` instead of using `routeRegex`, default is `false` |
 | iceberg.tables.cdcField                  | Name of the field containing the CDC operation, `I`, `U`, or `D`, default is none                             |
 | iceberg.tables.upsertModeEnabled         | Set to `true` to enable upsert mode, default is `false`                                                       |
-| iceberg.control.topic                    | Name of the control topic, default is `control-<connector name>`                                            |
-| iceberg.control.group.id                 | Name of the consumer group to store offsets, default is `cg-control-<connector name>`                       |
+| iceberg.control.topic                    | Name of the control topic, default is `control-iceberg`                                                       |
+| iceberg.control.group.id                 | Name of the consumer group to store offsets, default is `cg-control-<connector name>`                         |
 | iceberg.control.commitIntervalMs         | Commit interval in msec, default is 300,000 (5 min)                                                           |
 | iceberg.control.commitTimeoutMs          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                   |
 | iceberg.control.commitThreads            | Number of threads to use for commits, default is (cores * 2)                                                  |
@@ -59,13 +59,13 @@ distribution, so you will need to include those if needed.
 This assumes the source topic already exists and is named `events`.
 
 ### Control topic
-If your Kafka cluster has `auto.create.topics.enable` set to `true` (the default), then the control topic will be automatically created. If not, then you will need to create the topic first. The default topic name is `control-<connector name>`:
+If your Kafka cluster has `auto.create.topics.enable` set to `true` (the default), then the control topic will be automatically created. If not, then you will need to create the topic first. The default topic name is `control-iceberg`:
 ```bash
 bin/kafka-topics  \
   --command-config command-config.props \
   --bootstrap-server ${CONNECT_BOOTSTRAP_SERVERS} \
   --create \
-  --topic control-events-sink \
+  --topic control-iceberg \
   --partitions 1
 ```
 *NOTE: Clusters running on Confluent Cloud have `auto.create.topics.enable` set to `false` by default.*

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ subprojects {
   apply plugin: "maven-publish"
 
   group "io.tabular.connect"
-  version "0.3.8-SNAPSHOT"
+  version "0.3.8"
 
   repositories {
     mavenCentral()

--- a/docs/events.md
+++ b/docs/events.md
@@ -20,6 +20,7 @@ Iceberg writes the Avro schema with the manifest files, so the data files events
   * ID
   * Timestamp
   * Type
+  * Connector
   * Payload (one of)
     * Commit request payload
       * Commit ID

--- a/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/Event.java
+++ b/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/Event.java
@@ -32,6 +32,7 @@ public class Event implements Element {
   private UUID id;
   private EventType type;
   private Long timestamp;
+  private String connector;
   private Payload payload;
   private Schema avroSchema;
 
@@ -55,10 +56,11 @@ public class Event implements Element {
     this.avroSchema = avroSchema;
   }
 
-  public Event(EventType type, Payload payload) {
+  public Event(String connector, EventType type, Payload payload) {
     this.id = UUID.randomUUID();
     this.type = type;
     this.timestamp = System.currentTimeMillis();
+    this.connector = connector;
     this.payload = payload;
 
     this.avroSchema =
@@ -83,6 +85,12 @@ public class Event implements Element {
             .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
             .type(payload.getSchema())
             .noDefault()
+            .name("connector")
+            .prop(FIELD_ID_PROP, DUMMY_FIELD_ID)
+            .type()
+            .nullable() // for backwards compatibility
+            .stringType()
+            .noDefault()
             .endRecord();
   }
 
@@ -100,6 +108,10 @@ public class Event implements Element {
 
   public Payload getPayload() {
     return payload;
+  }
+
+  public String getConnector() {
+    return connector;
   }
 
   @Override
@@ -122,6 +134,9 @@ public class Event implements Element {
       case 3:
         this.payload = (Payload) v;
         return;
+      case 4:
+        this.connector = v == null ? null : v.toString();
+        return;
       default:
         // ignore the object, it must be from a newer version of the format
     }
@@ -138,6 +153,8 @@ public class Event implements Element {
         return timestamp;
       case 3:
         return payload;
+      case 4:
+        return connector;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + i);
     }

--- a/kafka-connect-events/src/test/java/io/tabular/iceberg/connect/events/EventSerializationTest.java
+++ b/kafka-connect-events/src/test/java/io/tabular/iceberg/connect/events/EventSerializationTest.java
@@ -33,7 +33,8 @@ public class EventSerializationTest {
   @Test
   public void testCommitRequestSerialization() {
     UUID commitId = UUID.randomUUID();
-    Event event = new Event(EventType.COMMIT_REQUEST, new CommitRequestPayload(commitId));
+    Event event =
+        new Event("connector", EventType.COMMIT_REQUEST, new CommitRequestPayload(commitId));
 
     byte[] data = Event.encode(event);
     Event result = Event.decode(data);
@@ -48,6 +49,7 @@ public class EventSerializationTest {
     UUID commitId = UUID.randomUUID();
     Event event =
         new Event(
+            "connector",
             EventType.COMMIT_RESPONSE,
             new CommitResponsePayload(
                 StructType.of(),
@@ -74,6 +76,7 @@ public class EventSerializationTest {
     UUID commitId = UUID.randomUUID();
     Event event =
         new Event(
+            "connector",
             EventType.COMMIT_READY,
             new CommitReadyPayload(
                 commitId,
@@ -96,6 +99,7 @@ public class EventSerializationTest {
     UUID commitId = UUID.randomUUID();
     Event event =
         new Event(
+            "connector",
             EventType.COMMIT_TABLE,
             new CommitTablePayload(
                 commitId, new TableName(Collections.singletonList("db"), "tbl"), 1L, 2L));
@@ -114,7 +118,8 @@ public class EventSerializationTest {
   @Test
   public void testCommitCompleteSerialization() {
     UUID commitId = UUID.randomUUID();
-    Event event = new Event(EventType.COMMIT_COMPLETE, new CommitCompletePayload(commitId, 2L));
+    Event event =
+        new Event("connector", EventType.COMMIT_COMPLETE, new CommitCompletePayload(commitId, 2L));
 
     byte[] data = Event.encode(event);
     Event result = Event.decode(data);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -75,7 +75,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String NAME_PROP = "name";
   private static final String BOOTSTRAP_SERVERS_PROP = "bootstrap.servers";
 
-  private static final String DEFAULT_CONTROL_TOPIC_PREFIX = "control-";
+  private static final String DEFAULT_CONTROL_TOPIC = "control-iceberg";
   public static final String DEFAULT_CONTROL_GROUP_PREFIX = "cg-control-";
 
   public static ConfigDef CONFIG_DEF = newConfigDef();
@@ -127,7 +127,11 @@ public class IcebergSinkConfig extends AbstractConfig {
         "Set to true to treat all appends as upserts, false otherwise");
     configDef.define(CATALOG_IMPL_PROP, Type.STRING, Importance.HIGH, "Iceberg catalog class name");
     configDef.define(
-        CONTROL_TOPIC_PROP, Type.STRING, null, Importance.MEDIUM, "Name of the control topic");
+        CONTROL_TOPIC_PROP,
+        Type.STRING,
+        DEFAULT_CONTROL_TOPIC,
+        Importance.MEDIUM,
+        "Name of the control topic");
     configDef.define(
         CONTROL_GROUP_ID_PROP,
         Type.STRING,
@@ -252,13 +256,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   }
 
   public String getControlTopic() {
-    String result = getString(CONTROL_TOPIC_PROP);
-    if (result != null) {
-      return result;
-    }
-    String connectorName = getConnectorName();
-    Preconditions.checkNotNull(connectorName);
-    return DEFAULT_CONTROL_TOPIC_PREFIX + connectorName;
+    return getString(CONTROL_TOPIC_PROP);
   }
 
   public String getControlGroupId() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -86,7 +86,9 @@ public class Coordinator extends Channel {
       commitState.startNewCommit();
       Event event =
           new Event(
-              EventType.COMMIT_REQUEST, new CommitRequestPayload(commitState.getCurrentCommitId()));
+              config.getConnectorName(),
+              EventType.COMMIT_REQUEST,
+              new CommitRequestPayload(commitState.getCurrentCommitId()));
       send(event);
     }
 
@@ -158,6 +160,7 @@ public class Coordinator extends Channel {
 
     Event event =
         new Event(
+            config.getConnectorName(),
             EventType.COMMIT_COMPLETE,
             new CommitCompletePayload(commitState.getCurrentCommitId(), vtts));
     send(event);
@@ -240,6 +243,7 @@ public class Coordinator extends Channel {
       Long snapshotId = table.currentSnapshot().snapshotId();
       Event event =
           new Event(
+              config.getConnectorName(),
               EventType.COMMIT_TABLE,
               new CommitTablePayload(
                   commitState.getCurrentCommitId(),

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -148,6 +148,7 @@ public class Worker extends Channel {
             .map(
                 writeResult ->
                     new Event(
+                        config.getConnectorName(),
                         EventType.COMMIT_RESPONSE,
                         new CommitResponsePayload(
                             writeResult.getPartitionStruct(),
@@ -158,7 +159,10 @@ public class Worker extends Channel {
             .collect(toList());
 
     Event readyEvent =
-        new Event(EventType.COMMIT_READY, new CommitReadyPayload(commitId, assignments));
+        new Event(
+            config.getConnectorName(),
+            EventType.COMMIT_READY,
+            new CommitReadyPayload(commitId, assignments));
     events.add(readyEvent);
 
     send(events, offsets);

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
@@ -79,6 +79,7 @@ public class ChannelTestBase {
     when(config.getControlTopic()).thenReturn(CTL_TOPIC_NAME);
     when(config.getControlGroupId()).thenReturn("group");
     when(config.getCommitThreads()).thenReturn(1);
+    when(config.getConnectorName()).thenReturn("connector");
 
     TopicPartitionInfo partitionInfo = mock(TopicPartitionInfo.class);
     when(partitionInfo.partition()).thenReturn(0);

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -162,6 +162,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
     Event commitResponse =
         new Event(
+            config.getConnectorName(),
             EventType.COMMIT_RESPONSE,
             new CommitResponsePayload(
                 StructType.of(),
@@ -174,6 +175,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
     Event commitReady =
         new Event(
+            config.getConnectorName(),
             EventType.COMMIT_READY,
             new CommitReadyPayload(
                 commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts))));

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -95,7 +95,11 @@ public class WorkerTest extends ChannelTestBase {
     worker.save(ImmutableList.of(rec));
 
     UUID commitId = UUID.randomUUID();
-    Event commitRequest = new Event(EventType.COMMIT_REQUEST, new CommitRequestPayload(commitId));
+    Event commitRequest =
+        new Event(
+            config.getConnectorName(),
+            EventType.COMMIT_REQUEST,
+            new CommitRequestPayload(commitId));
     byte[] bytes = Event.encode(commitRequest);
     consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
 


### PR DESCRIPTION
This PR changes the default config to use a single control topic rather than a different control topic for every connector. Events are filtered by connector name. The control topic can still be configured on a per-connector basis if desired.