### PR TITLE
Add SMT project with copy value SMT

### DIFF
--- a/kafka-connect-runtime/build.gradle
+++ b/kafka-connect-runtime/build.gradle
@@ -16,6 +16,7 @@ configurations {
 
 dependencies {
   implementation project(":iceberg-kafka-connect")
+  implementation project(":iceberg-kafka-connect-transforms")
   implementation libs.bundles.iceberg.ext
   implementation libs.bundles.aws
   implementation(libs.hadoop.common) {

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -1,0 +1,24 @@
+# SMTs for the Apache Iceberg Sink Connector
+
+This project contains some SMTs that could be useful when transforming Kafka data for use by
+the Iceberg sink connector.
+
+# CopyValue
+
+The `CopyValue` SMT copies a value from one field to a new field.
+
+## Configuration
+
+| Property         | Description       |
+|------------------|-------------------|
+| source.field     | Source field name |
+| target.field     | Target field name |
+
+## Example
+
+```sql
+"transforms": "copyId",
+"transforms.copyId.type": "io.tabular.iceberg.connect.transforms.CopyValue",
+"transforms.copyId.source.field": "id",
+"transforms.copyId.target.field": "id_copy",
+```

--- a/kafka-connect-transforms/build.gradle
+++ b/kafka-connect-transforms/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+  implementation libs.slf4j
+  compileOnly libs.bundles.kafka.connect
+
+  testImplementation libs.junit.api
+  testRuntimeOnly libs.junit.engine
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
+}

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CopyValue.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CopyValue.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transforms;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+import java.util.HashMap;
+import java.util.Map;
+import jdk.jfr.Experimental;
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+@Experimental
+public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> {
+
+  private interface ConfigName {
+
+    String SOURCE_FIELD = "source.field";
+    String TARGET_FIELD = "target.field";
+  }
+
+  public static final ConfigDef CONFIG_DEF =
+      new ConfigDef()
+          .define(
+              ConfigName.SOURCE_FIELD,
+              ConfigDef.Type.STRING,
+              ConfigDef.Importance.HIGH,
+              "Source field name.")
+          .define(
+              ConfigName.TARGET_FIELD,
+              ConfigDef.Type.STRING,
+              ConfigDef.Importance.HIGH,
+              "Target field name.");
+
+  private String sourceField;
+  private String targetField;
+  private Cache<Schema, Schema> schemaUpdateCache;
+
+  @Override
+  public void configure(Map<String, ?> props) {
+    final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+    sourceField = config.getString(ConfigName.SOURCE_FIELD);
+    targetField = config.getString(ConfigName.TARGET_FIELD);
+    schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+  }
+
+  @Override
+  public R apply(R record) {
+    if (operatingValue(record) == null) {
+      return record;
+    } else if (operatingSchema(record) == null) {
+      return applySchemaless(record);
+    } else {
+      return applyWithSchema(record);
+    }
+  }
+
+  private R applySchemaless(R record) {
+    final Map<String, Object> value = requireMap(operatingValue(record), "copy value");
+
+    final Map<String, Object> updatedValue = new HashMap<>(value);
+    updatedValue.put(targetField, value.get(sourceField));
+
+    return newRecord(record, null, updatedValue);
+  }
+
+  private R applyWithSchema(R record) {
+    final Struct value = requireStruct(operatingValue(record), "copy value");
+
+    Schema updatedSchema = schemaUpdateCache.get(value.schema());
+    if (updatedSchema == null) {
+      updatedSchema = makeUpdatedSchema(value.schema());
+      schemaUpdateCache.put(value.schema(), updatedSchema);
+    }
+
+    final Struct updatedValue = new Struct(updatedSchema);
+
+    for (Field field : value.schema().fields()) {
+      updatedValue.put(field.name(), value.get(field));
+    }
+    updatedValue.put(targetField, value.get(sourceField));
+
+    return newRecord(record, updatedSchema, updatedValue);
+  }
+
+  private Schema makeUpdatedSchema(Schema schema) {
+    final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+
+    for (Field field : schema.fields()) {
+      builder.field(field.name(), field.schema());
+    }
+    builder.field(targetField, schema.field(sourceField).schema());
+
+    return builder.build();
+  }
+
+  @Override
+  public void close() {
+    schemaUpdateCache = null;
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  protected Schema operatingSchema(R record) {
+    return record.valueSchema();
+  }
+
+  protected Object operatingValue(R record) {
+    return record.value();
+  }
+
+  protected R newRecord(R record, Schema updatedSchema, Object updatedValue) {
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        updatedSchema,
+        updatedValue,
+        record.timestamp());
+  }
+}

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/CopyValueTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/CopyValueTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transforms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+public class CopyValueTest {
+
+  @Test
+  public void testCopyValueNull() {
+    try (CopyValue<SinkRecord> smt = new CopyValue<>()) {
+      SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
+      SinkRecord result = smt.apply(record);
+      assertNull(result.value());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testCopyValueSchemaless() {
+    Map<String, String> props = new HashMap<>();
+    props.put("source.field", "data");
+    props.put("target.field", "data_copy");
+
+    Map<String, Object> value = new HashMap<>();
+    value.put("id", 123L);
+    value.put("data", "foobar");
+
+    try (CopyValue<SinkRecord> smt = new CopyValue<>()) {
+      smt.configure(props);
+      SinkRecord record = new SinkRecord("topic", 0, null, null, null, value, 0);
+      SinkRecord result = smt.apply(record);
+      Map<String, Object> newValue = (Map<String, Object>) result.value();
+      assertEquals(3, newValue.size());
+      assertEquals("foobar", newValue.get("data_copy"));
+    }
+  }
+
+  @Test
+  public void testCopyValueWithSchema() {
+    Map<String, String> props = new HashMap<>();
+    props.put("source.field", "data");
+    props.put("target.field", "data_copy");
+
+    Schema schema =
+        SchemaBuilder.struct().field("id", Schema.INT64_SCHEMA).field("data", Schema.STRING_SCHEMA);
+
+    Struct value = new Struct(schema).put("id", 123L).put("data", "foobar");
+
+    try (CopyValue<SinkRecord> smt = new CopyValue<>()) {
+      smt.configure(props);
+      SinkRecord record = new SinkRecord("topic", 0, null, null, schema, value, 0);
+      SinkRecord result = smt.apply(record);
+
+      Schema newSchema = result.valueSchema();
+      assertEquals(3, newSchema.fields().size());
+      assertEquals(Schema.STRING_SCHEMA, newSchema.field("data_copy").schema());
+
+      Struct newValue = (Struct) result.value();
+      assertEquals("foobar", newValue.get("data_copy"));
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,5 +12,8 @@ project(":iceberg-kafka-connect").projectDir = file("kafka-connect")
 include "iceberg-kafka-connect-events"
 project(":iceberg-kafka-connect-events").projectDir = file("kafka-connect-events")
 
+include "iceberg-kafka-connect-transforms"
+project(":iceberg-kafka-connect-transforms").projectDir = file("kafka-connect-transforms")
+
 include "iceberg-kafka-connect-runtime"
 project(":iceberg-kafka-connect-runtime").projectDir = file("kafka-connect-runtime")

--- a/versions.toml
+++ b/versions.toml
@@ -39,6 +39,7 @@ iceberg-parquet = { module = "org.apache.iceberg:iceberg-parquet", version.ref =
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka-ver" }
 kafka-connect-api = { module = "org.apache.kafka:connect-api", version.ref = "kafka-ver" }
 kafka-connect-json = { module = "org.apache.kafka:connect-json", version.ref = "kafka-ver" }
+kafka-connect-transforms = { module = "org.apache.kafka:connect-transforms", version.ref = "kafka-ver" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson-ver" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-ver" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-ver" }
@@ -59,4 +60,4 @@ aws = ["aws-dynamodb", "aws-glue", "aws-kms", "aws-s3", "aws-sso", "aws-sts"]
 iceberg = ["iceberg-api", "iceberg-common", "iceberg-core", "iceberg-data", "iceberg-guava", "iceberg-orc", "iceberg-parquet"]
 iceberg-ext = ["iceberg-aws", "iceberg-gcp", "iceberg-nessie"]
 jackson = ["jackson-core", "jackson-databind"]
-kafka-connect = ["kafka-clients", "kafka-connect-api", "kafka-connect-json"]
+kafka-connect = ["kafka-clients", "kafka-connect-api", "kafka-connect-json", "kafka-connect-transforms"]


### PR DESCRIPTION
This PR adds a `kafka-connect-transforms` project for adding transforms that might be useful for use with the sink connector. For now it only contains one SMT but others are planned.