### PR TITLE
Track source offsets in worker

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/WriterResult.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/WriterResult.java
@@ -19,12 +19,10 @@
 package io.tabular.iceberg.connect.data;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types.StructType;
-import org.apache.kafka.common.TopicPartition;
 
 public class WriterResult {
 
@@ -32,19 +30,16 @@ public class WriterResult {
   private final List<DataFile> dataFiles;
   private final List<DeleteFile> deleteFiles;
   private final StructType partitionStruct;
-  private final Map<TopicPartition, Offset> offsets;
 
   public WriterResult(
       TableIdentifier tableIdentifier,
       List<DataFile> dataFiles,
       List<DeleteFile> deleteFiles,
-      StructType partitionStruct,
-      Map<TopicPartition, Offset> offsets) {
+      StructType partitionStruct) {
     this.tableIdentifier = tableIdentifier;
     this.dataFiles = dataFiles;
     this.deleteFiles = deleteFiles;
     this.partitionStruct = partitionStruct;
-    this.offsets = offsets;
   }
 
   public TableIdentifier getTableIdentifier() {
@@ -61,9 +56,5 @@ public class WriterResult {
 
   public StructType getPartitionStruct() {
     return partitionStruct;
-  }
-
-  public Map<TopicPartition, Offset> getOffsets() {
-    return offsets;
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.data.IcebergWriter;
 import io.tabular.iceberg.connect.data.IcebergWriterFactory;
-import io.tabular.iceberg.connect.data.Offset;
 import io.tabular.iceberg.connect.data.WriterResult;
 import io.tabular.iceberg.connect.events.CommitReadyPayload;
 import io.tabular.iceberg.connect.events.CommitRequestPayload;
@@ -76,8 +75,7 @@ public class WorkerTest extends ChannelTestBase {
             TableIdentifier.parse(TABLE_NAME),
             ImmutableList.of(createDataFile()),
             ImmutableList.of(),
-            StructType.of(),
-            ImmutableMap.of(new TopicPartition(SRC_TOPIC_NAME, 0), new Offset(0L, 0L)));
+            StructType.of());
     IcebergWriter writer = mock(IcebergWriter.class);
     when(writer.complete()).thenReturn(writeResult);
 

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -114,5 +114,8 @@ public class WorkerTest extends ChannelTestBase {
     assertEquals(EventType.COMMIT_READY, event.getType());
     CommitReadyPayload readyPayload = (CommitReadyPayload) event.getPayload();
     assertEquals(commitId, readyPayload.getCommitId());
+    assertEquals(1, readyPayload.getAssignments().size());
+    // offset should be one more than the record offset
+    assertEquals(1L, readyPayload.getAssignments().get(0).getOffset());
   }
 }


### PR DESCRIPTION
This PR moves tracking offsets from the writer to the worker. This allows us to track offsets even if nothing was written from a given partition.