### PR TITLE
Add SMT to tranform DMS messages for CDC

### DIFF
--- a/kafka-connect-transforms/build.gradle
+++ b/kafka-connect-transforms/build.gradle
@@ -4,6 +4,9 @@ dependencies {
 
   testImplementation libs.junit.api
   testRuntimeOnly libs.junit.engine
+
+  testImplementation libs.mockito
+  testImplementation libs.assertj
 }
 
 configurations {

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CopyValue.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CopyValue.java
@@ -73,9 +73,9 @@ public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> 
 
   @Override
   public R apply(R record) {
-    if (operatingValue(record) == null) {
+    if (record.value() == null) {
       return record;
-    } else if (operatingSchema(record) == null) {
+    } else if (record.valueSchema() == null) {
       return applySchemaless(record);
     } else {
       return applyWithSchema(record);
@@ -83,7 +83,7 @@ public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> 
   }
 
   private R applySchemaless(R record) {
-    final Map<String, Object> value = requireMap(operatingValue(record), "copy value");
+    final Map<String, Object> value = requireMap(record.value(), "copy value");
 
     final Map<String, Object> updatedValue = new HashMap<>(value);
     updatedValue.put(targetField, value.get(sourceField));
@@ -92,7 +92,7 @@ public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> 
   }
 
   private R applyWithSchema(R record) {
-    final Struct value = requireStruct(operatingValue(record), "copy value");
+    final Struct value = requireStruct(record.value(), "copy value");
 
     Schema updatedSchema = schemaUpdateCache.get(value.schema());
     if (updatedSchema == null) {
@@ -129,14 +129,6 @@ public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> 
   @Override
   public ConfigDef config() {
     return CONFIG_DEF;
-  }
-
-  protected Schema operatingSchema(R record) {
-    return record.valueSchema();
-  }
-
-  protected Object operatingValue(R record) {
-    return record.value();
   }
 
   protected R newRecord(R record, Schema updatedSchema, Object updatedValue) {

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/DmsTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/DmsTransform.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transforms;
+
+import static java.lang.String.format;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import jdk.jfr.Experimental;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Experimental
+public class DmsTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DmsTransform.class.getName());
+  private static final ConfigDef EMPTY_CONFIG = new ConfigDef();
+
+  @Override
+  public R apply(R record) {
+    if (record.value() == null) {
+      return record;
+    } else if (record.valueSchema() == null) {
+      return applySchemaless(record);
+    } else {
+      throw new UnsupportedOperationException("Schema not support for DMS records");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private R applySchemaless(R record) {
+    final Map<String, Object> value = requireMap(record.value(), "DMS transform");
+
+    // promote fields under "data"
+    Object dataObj = value.get("data");
+    Object metadataObj = value.get("metadata");
+    if (!(dataObj instanceof Map) || !(metadataObj instanceof Map)) {
+      LOG.warn("Unable to transform DMS record, leaving as-is...");
+      return record;
+    }
+
+    final Map<String, Object> result = new HashMap<>((Map<String, Object>) dataObj);
+
+    Map<String, Object> metadata = (Map<String, Object>) metadataObj;
+
+    String dmsOp = metadata.get("operation").toString();
+    String op;
+    switch (dmsOp) {
+      case "update":
+        op = "U";
+        break;
+      case "delete":
+        op = "D";
+        break;
+      default:
+        op = "I";
+    }
+
+    result.put("_cdc_op", op);
+    result.put(
+        "_cdc_table", format("%s.%s", metadata.get("schema-name"), metadata.get("table-name")));
+    result.put("_cdc_ts", metadata.get("timestamp"));
+
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        null,
+        result,
+        record.timestamp());
+  }
+
+  @Override
+  public ConfigDef config() {
+    return EMPTY_CONFIG;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> configs) {}
+}

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DmsTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DmsTransformTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+public class DmsTransformTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testDmsTransform() {
+    try (DmsTransform<SinkRecord> smt = new DmsTransform<>()) {
+      Map<String, Object> event = createDmsEvent("update");
+      SinkRecord record = new SinkRecord("topic", 0, null, null, null, event, 0);
+
+      SinkRecord result = smt.apply(record);
+      assertThat(result.value()).isInstanceOf(Map.class);
+      Map<String, Object> value = (Map<String, Object>) result.value();
+
+      assertEquals(value.get("account_id"), 1);
+      assertEquals(value.get("_cdc_table"), "db.tbl");
+      assertEquals(value.get("_cdc_op"), "U");
+    }
+  }
+
+  @Test
+  public void testDmsTransformNull() {
+    try (DmsTransform<SinkRecord> smt = new DmsTransform<>()) {
+      SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
+      SinkRecord result = smt.apply(record);
+      assertNull(result.value());
+    }
+  }
+
+  private Map<String, Object> createDmsEvent(String operation) {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("timestamp", Instant.now().toString());
+    metadata.put("record-type", "data");
+    metadata.put("operation", operation);
+    metadata.put("partition-key-type", "schema-table");
+    metadata.put("schema-name", "db");
+    metadata.put("table-name", "tbl");
+    metadata.put("transaction-id", 12345);
+
+    Map<String, Object> data = new HashMap<>();
+    data.put("account_id", 1);
+    data.put("balance", 100);
+    data.put("last_updated", Instant.now().toString());
+
+    Map<String, Object> event = new HashMap<>();
+    event.put("metadata", metadata);
+    event.put("data", data);
+
+    return event;
+  }
+}


### PR DESCRIPTION
This PR adds an SMT that can be used to transform DMS records for use with the sink's CDC feature.