### PR TITLE
Add support for Azure storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ subprojects {
   apply plugin: "maven-publish"
 
   group "io.tabular.connect"
-  version "0.4.10-SNAPSHOT"
+  version "0.4.10"
 
   repositories {
     mavenCentral()

--- a/kafka-connect-runtime/build.gradle
+++ b/kafka-connect-runtime/build.gradle
@@ -12,6 +12,11 @@ configurations {
     resolutionStrategy.force "org.codehaus.jettison:jettison:1.5.4"
     resolutionStrategy.force "org.xerial.snappy:snappy-java:1.1.10.1"
     resolutionStrategy.force "org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1-tabular"
+    resolutionStrategy.eachDependency { details ->
+      if (details.requested.group == "io.netty") {
+        details.useVersion "4.1.86.Final"
+      }
+    }
   }
 }
 
@@ -19,11 +24,14 @@ dependencies {
   implementation project(":iceberg-kafka-connect")
   implementation project(":iceberg-kafka-connect-transforms")
   implementation libs.bundles.iceberg.ext
-  implementation libs.bundles.aws
   implementation(libs.hadoop.common) {
     exclude group: "log4j"
     exclude group: "org.slf4j"
     exclude group: "ch.qos.reload4j"
+    // exclude dependencies that have vulnerabilities and shouldn't be needed...
+    exclude group: "com.google.guava"
+    exclude group: "com.google.protobuf"
+    exclude group: "org.apache.hadoop.thirdparty", module: "hadoop-shaded-protobuf_3_7"
   }
 
   hive libs.iceberg.hive.metastore
@@ -54,7 +62,7 @@ dependencies {
   }
 
   testImplementation libs.bundles.iceberg
-  testImplementation libs.bundles.aws
+  testImplementation libs.iceberg.aws.bundle
   testImplementation libs.bundles.jackson
   testImplementation libs.bundles.kafka.connect
 

--- a/versions.toml
+++ b/versions.toml
@@ -2,11 +2,10 @@
 assertj-ver = "3.23.1"
 avro-ver = "1.11.1"
 awaitility-ver = "4.2.0"
-aws-ver = "2.20.18"
 hadoop-ver = "3.3.6"
 hive-ver = "2.3.9"
 http-client-ver = "5.2.1"
-iceberg-ver = "1.3.1-tabular.11"
+iceberg-ver = "1.3.1-tabular.17"
 jackson-ver = "2.14.2"
 junit-ver = "5.9.2"
 kafka-ver = "3.5.1"
@@ -16,21 +15,19 @@ testcontainers-ver = "1.18.1"
 
 [libraries]
 avro = { module = "org.apache.avro:avro", version.ref = "avro-ver" }
-aws-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "aws-ver" }
-aws-glue = { module = "software.amazon.awssdk:glue", version.ref = "aws-ver" }
-aws-kms = { module = "software.amazon.awssdk:kms", version.ref = "aws-ver" }
-aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws-ver" }
-aws-sso = { module = "software.amazon.awssdk:sso", version.ref = "aws-ver" }
-aws-sts = { module = "software.amazon.awssdk:sts", version.ref = "aws-ver" }
 hadoop-client = { module = "org.apache.hadoop:hadoop-client", version.ref = "hadoop-ver" }
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop-ver" }
 hive-metastore = { module = "org.apache.hive:hive-metastore", version.ref = "hive-ver" }
 iceberg-api = { module = "org.apache.iceberg:iceberg-api", version.ref = "iceberg-ver" }
 iceberg-aws = { module = "org.apache.iceberg:iceberg-aws", version.ref = "iceberg-ver" }
+iceberg-aws-bundle = { module = "org.apache.iceberg:iceberg-aws-bundle", version.ref = "iceberg-ver" }
+iceberg-azure = { module = "org.apache.iceberg:iceberg-azure", version.ref = "iceberg-ver" }
+iceberg-azure-bundle = { module = "org.apache.iceberg:iceberg-azure-bundle", version.ref = "iceberg-ver" }
 iceberg-common = { module = "org.apache.iceberg:iceberg-common", version.ref = "iceberg-ver" }
 iceberg-core = { module = "org.apache.iceberg:iceberg-core", version.ref = "iceberg-ver" }
 iceberg-data = { module = "org.apache.iceberg:iceberg-data", version.ref = "iceberg-ver" }
 iceberg-gcp = { module = "org.apache.iceberg:iceberg-gcp", version.ref = "iceberg-ver" }
+iceberg-gcp-bundle = { module = "org.apache.iceberg:iceberg-gcp-bundle", version.ref = "iceberg-ver" }
 iceberg-guava = { module = "org.apache.iceberg:iceberg-bundled-guava", version.ref = "iceberg-ver" }
 iceberg-hive-metastore = { module = "org.apache.iceberg:iceberg-hive-metastore", version.ref = "iceberg-ver" }
 iceberg-nessie = { module = "org.apache.iceberg:iceberg-nessie", version.ref = "iceberg-ver" }
@@ -56,8 +53,7 @@ testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "tes
 
 
 [bundles]
-aws = ["aws-dynamodb", "aws-glue", "aws-kms", "aws-s3", "aws-sso", "aws-sts"]
 iceberg = ["iceberg-api", "iceberg-common", "iceberg-core", "iceberg-data", "iceberg-guava", "iceberg-orc", "iceberg-parquet"]
-iceberg-ext = ["iceberg-aws", "iceberg-gcp", "iceberg-nessie"]
+iceberg-ext = ["iceberg-aws", "iceberg-aws-bundle", "iceberg-azure", "iceberg-azure-bundle", "iceberg-gcp","iceberg-gcp-bundle", "iceberg-nessie"]
 jackson = ["jackson-core", "jackson-databind"]
 kafka-connect = ["kafka-clients", "kafka-connect-api", "kafka-connect-json", "kafka-connect-transforms"]


### PR DESCRIPTION
This PR adds support for Azure storage. It uses a version of Iceberg 1.3.1 with the Azure support backported.