### PR TITLE
Support loading Hadoop config files from a specified directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ otherwise you will need to include that yourself.
 To set the catalog type, you can set `iceberg.catalog.type` to `rest`, `hive`, or `hadoop`. For other
 catalog types, you need to instead set `iceberg.catalog.catalog-impl` to the name of the catalog class.
 
+## Hadoop configuration
+
+When using HDFS or Hive, the sink will initialize the Hadoop configuration. First, config files
+from the classpath are loaded. Next, if `iceberg.hadoop-conf-dir` is specified, config files
+are loaded from that location. Finally, any `iceberg.hadoop.*` properties from the sink config are
+applied. When merging these, the order of precedence is sink config > config dir > classpath.
 
 ### REST example
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.control.commitThreads            | Number of threads to use for commits, default is (cores * 2)                                                  |
 | iceberg.catalog                          | Name of the catalog, default is `iceberg`                                                                     |
 | iceberg.catalog.*                        | Properties passed through to Iceberg catalog initialization                                                   |
-| iceberg.hadoop.*                         | Properties passed through to Hadoop configuration                                                             |
+| iceberg.hadoop-conf-dir                  | If specified, Hadoop config files in this directory will be loaded                                            |
+| iceberg.hadoop.*                         | Properties passed through to the Hadoop configuration                                                         |
 | iceberg.kafka.*                          | Properties passed through to control topic Kafka client initialization                                        |
 
 If `iceberg.tables.dynamic.enabled` is `false` (the default) then you must specify `iceberg.tables`. If

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility-v
 http-client = { module =  "org.apache.httpcomponents.client5:httpclient5", version.ref = "http-client-ver" }
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-ver" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-ver" }
+junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-ver" }
 mockito = "org.mockito:mockito-core:4.8.1"
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers-ver" }
 testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainers-ver" }

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   testImplementation libs.hadoop.common
 
   testImplementation libs.junit.api
+  testImplementation libs.junit.params
   testRuntimeOnly libs.junit.engine
 
   testImplementation libs.mockito

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -72,6 +72,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String COMMIT_TIMEOUT_MS_PROP = "iceberg.control.commitTimeoutMs";
   private static final int COMMIT_TIMEOUT_MS_DEFAULT = 30_000;
   private static final String COMMIT_THREADS_PROP = "iceberg.control.commitThreads";
+  private static final String HADDOP_CONF_DIR_PROP = "iceberg.hadoop-conf-dir";
 
   private static final String NAME_PROP = "name";
   private static final String BOOTSTRAP_SERVERS_PROP = "bootstrap.servers";
@@ -161,6 +162,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         COMMIT_THREADS_PROP,
         Type.INT,
         Runtime.getRuntime().availableProcessors() * 2,
+        Importance.MEDIUM,
+        "Coordinator threads to use for table commits, default is (cores * 2)");
+    configDef.define(
+        HADDOP_CONF_DIR_PROP,
+        Type.STRING,
+        null,
         Importance.MEDIUM,
         "Coordinator threads to use for table commits, default is (cores * 2)");
     return configDef;
@@ -293,6 +300,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public int getCommitThreads() {
     return getInt(COMMIT_THREADS_PROP);
+  }
+
+  public String getHadoopConfDir() {
+    return getString(HADDOP_CONF_DIR_PROP);
   }
 
   public boolean isUpsertMode() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
@@ -24,7 +24,13 @@ import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -41,6 +47,7 @@ import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.UnpartitionedWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
 import org.apache.iceberg.types.TypeUtil;
@@ -52,15 +59,16 @@ import org.slf4j.LoggerFactory;
 public class Utilities {
 
   private static final Logger LOG = LoggerFactory.getLogger(Utilities.class.getName());
+  private static final List<String> HADOOP_CONF_FILES =
+      ImmutableList.of("core-site.xml", "hdfs-site.xml", "hive-site.xml");
 
   public static Catalog loadCatalog(IcebergSinkConfig config) {
     return CatalogUtil.buildIcebergCatalog(
-        config.getCatalogName(),
-        config.getCatalogProps(),
-        getHadoopConfig(config.getHadoopProps()));
+        config.getCatalogName(), config.getCatalogProps(), getHadoopConfig(config));
   }
 
-  private static Object getHadoopConfig(Map<String, String> hadoopProps) {
+  // use reflection here to avoid requiring Hadoop as a dependency
+  private static Object getHadoopConfig(IcebergSinkConfig config) {
     Class<?> configClass =
         DynClasses.builder().impl("org.apache.hadoop.hdfs.HdfsConfiguration").orNull().build();
     if (configClass == null) {
@@ -75,9 +83,30 @@ public class Utilities {
 
     try {
       Object result = configClass.getDeclaredConstructor().newInstance();
+      BoundMethod addResourceMethod =
+          DynMethods.builder("addResource").impl(configClass, URL.class).build(result);
       BoundMethod setMethod =
           DynMethods.builder("set").impl(configClass, String.class, String.class).build(result);
-      hadoopProps.forEach(setMethod::invoke);
+
+      //  load any config files in the specified config directory
+      String hadoopConfDir = config.getHadoopConfDir();
+      if (hadoopConfDir != null) {
+        HADOOP_CONF_FILES.forEach(
+            confFile -> {
+              Path path = Paths.get(hadoopConfDir, confFile);
+              if (Files.exists(path)) {
+                try {
+                  addResourceMethod.invoke(path.toUri().toURL());
+                } catch (IOException e) {
+                  LOG.warn("Error adding Hadoop resource {}, resource was not added", path, e);
+                }
+              }
+            });
+      }
+
+      // set any Hadoop properties specified in the sink config
+      config.getHadoopProps().forEach(setMethod::invoke);
+
       LOG.info("Hadoop config initialized: {}", configClass.getName());
       return result;
     } catch (InstantiationException

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,3 @@
-dependencyResolutionManagement {
-  versionCatalogs {
-    libs {
-      from(files("versions.toml"))
-    }
-  }
-}
-
 include "iceberg-kafka-connect"
 project(":iceberg-kafka-connect").projectDir = file("kafka-connect")
 


### PR DESCRIPTION
This PR adds a new config property, `iceberg.hadoop-conf-dir`, for specifying a directory containing Hadoop configuration files.  If specified, any files named `core-site.xml`, `hdfs-site.xml`, or `hive-site.xml` in this directory will be loaded into the Hadoop configuration (in that order). Hadoop properties in the sink config take precedence. Next precedence are properties loaded from the config directory. Lowest precedence are properties in config files loaded from the classpath.