### PR TITLE
Support java.util.Date in time and date conversions

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordConverter.java
@@ -312,6 +312,9 @@ public class RecordConverter {
       return LocalDate.parse((String) value);
     } else if (value instanceof LocalDate) {
       return (LocalDate) value;
+    } else if (value instanceof Date) {
+      int i = (int) (((Date) value).getTime() / 1000 / 60 / 60 / 24);
+      return DateTimeUtil.dateFromDays(i);
     }
     throw new RuntimeException("Cannot convert date: " + value);
   }
@@ -324,6 +327,9 @@ public class RecordConverter {
       return LocalTime.parse((String) value);
     } else if (value instanceof LocalTime) {
       return (LocalTime) value;
+    } else if (value instanceof Date) {
+      long l = ((Date) value).getTime();
+      return DateTimeUtil.timeFromMicros(l * 1000);
     }
     throw new RuntimeException("Cannot convert time: " + value);
   }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -230,6 +231,50 @@ public class RecordConverterTest {
     Map<String, Object> data = ImmutableMap.of("renamed_ii", 123);
     Record record = converter.convert(data);
     assertEquals(123, record.getField("ii"));
+  }
+
+  @Test
+  public void testDateConversion() {
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(SIMPLE_SCHEMA);
+    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+
+    LocalDate expected = LocalDate.of(2023, 11, 15);
+
+    List<Object> inputList =
+        ImmutableList.of(
+            "2023-11-15",
+            expected.toEpochDay(),
+            expected,
+            new Date(Duration.ofDays(expected.toEpochDay()).toMillis()));
+
+    inputList.forEach(
+        input -> {
+          Temporal ts = converter.convertDateValue(input);
+          assertEquals(expected, ts);
+        });
+  }
+
+  @Test
+  public void testTimeConversion() {
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(SIMPLE_SCHEMA);
+    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+
+    LocalTime expected = LocalTime.of(7, 51, 30, 888_000_000);
+
+    List<Object> inputList =
+        ImmutableList.of(
+            "07:51:30.888",
+            expected.toNanoOfDay() / 1000 / 1000,
+            expected,
+            new Date(expected.toNanoOfDay() / 1000 / 1000));
+
+    inputList.forEach(
+        input -> {
+          Temporal ts = converter.convertTimeValue(input);
+          assertEquals(expected, ts);
+        });
   }
 
   @Test


### PR DESCRIPTION
This PR adds conversion of `java.util.Date` in the time and the date conversion functions. It was already supported in the timestamp conversions.