### PR TITLE
Allow overriding control topic offset reset config

### DIFF
--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationCdcTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationCdcTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
@@ -135,7 +134,8 @@ public class IntegrationCdcTest extends IntegrationTestBase {
             .config("iceberg.catalog." + S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
             .config("iceberg.catalog." + S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
             .config("iceberg.catalog." + S3FileIOProperties.PATH_STYLE_ACCESS, true)
-            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION);
+            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION)
+            .config("iceberg.kafka.auto.offset.reset", "earliest");
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.defaultCommitBranch", branch);
@@ -162,7 +162,10 @@ public class IntegrationCdcTest extends IntegrationTestBase {
     send(testTopic, event5);
     flush();
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(this::assertSnapshotAdded);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(this::assertSnapshotAdded);
   }
 
   private void assertSnapshotAdded() {

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationDynamicTableTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationDynamicTableTest.java
@@ -26,8 +26,8 @@ import static io.tabular.iceberg.connect.TestEvent.TEST_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
@@ -112,7 +112,8 @@ public class IntegrationDynamicTableTest extends IntegrationTestBase {
             .config("iceberg.catalog." + S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
             .config("iceberg.catalog." + S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
             .config("iceberg.catalog." + S3FileIOProperties.PATH_STYLE_ACCESS, true)
-            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION);
+            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION)
+            .config("iceberg.kafka.auto.offset.reset", "earliest");
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.defaultCommitBranch", branch);
@@ -131,7 +132,10 @@ public class IntegrationDynamicTableTest extends IntegrationTestBase {
     send(testTopic, event3);
     flush();
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(this::assertSnapshotAdded);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(this::assertSnapshotAdded);
   }
 
   private void assertSnapshotAdded() {

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationMultiTableTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationMultiTableTest.java
@@ -27,8 +27,8 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
@@ -117,7 +117,8 @@ public class IntegrationMultiTableTest extends IntegrationTestBase {
             .config("iceberg.catalog." + S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
             .config("iceberg.catalog." + S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
             .config("iceberg.catalog." + S3FileIOProperties.PATH_STYLE_ACCESS, true)
-            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION);
+            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION)
+            .config("iceberg.kafka.auto.offset.reset", "earliest");
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.defaultCommitBranch", branch);
@@ -134,7 +135,10 @@ public class IntegrationMultiTableTest extends IntegrationTestBase {
     send(testTopic, event3);
     flush();
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(this::assertSnapshotAdded);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(this::assertSnapshotAdded);
   }
 
   private void assertSnapshotAdded() {

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
@@ -119,7 +118,8 @@ public class IntegrationTest extends IntegrationTestBase {
             .config("iceberg.catalog." + S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
             .config("iceberg.catalog." + S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
             .config("iceberg.catalog." + S3FileIOProperties.PATH_STYLE_ACCESS, true)
-            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION);
+            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION)
+            .config("iceberg.kafka.auto.offset.reset", "earliest");
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.defaultCommitBranch", branch);
@@ -135,7 +135,10 @@ public class IntegrationTest extends IntegrationTestBase {
     send(testTopic, event2);
     flush();
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(this::assertSnapshotAdded);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(this::assertSnapshotAdded);
   }
 
   private void assertSnapshotAdded() {

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTestBase.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTestBase.java
@@ -95,7 +95,6 @@ public class IntegrationTestBase {
               }
             });
     assertThat(props).containsKey("kafka.connect.commitId");
-    assertThat(props).containsKey("kafka.connect.vtts");
   }
 
   protected List<DataFile> getDataFiles(TableIdentifier tableIdentifier, String branch) {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/KafkaClientFactory.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/KafkaClientFactory.java
@@ -52,8 +52,8 @@ public class KafkaClientFactory {
 
   public Consumer<String, byte[]> createConsumer(String consumerGroupId) {
     Map<String, Object> consumerProps = new HashMap<>(kafkaProps);
+    consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
     consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
-    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
     consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
     consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
     consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString());


### PR DESCRIPTION
This PR allows the specified kafka config `auto.offset.reset` to take precedence for the control topic consumer. Also tests were updated to set this to `earliest` to ensure the data files written are committed in the integration tests.