### PR TITLE
Refactor integration tests to adopt other catalogs

### DIFF
--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/AbstractIntegrationCdcTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/AbstractIntegrationCdcTest.java
@@ -18,9 +18,6 @@
  */
 package io.tabular.iceberg.connect;
 
-import static io.tabular.iceberg.connect.TestConstants.AWS_ACCESS_KEY;
-import static io.tabular.iceberg.connect.TestConstants.AWS_REGION;
-import static io.tabular.iceberg.connect.TestConstants.AWS_SECRET_KEY;
 import static io.tabular.iceberg.connect.TestEvent.TEST_SCHEMA;
 import static io.tabular.iceberg.connect.TestEvent.TEST_SPEC;
 import static java.lang.String.format;
@@ -30,14 +27,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.List;
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.aws.AwsClientProperties;
-import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.awaitility.Awaitility;
@@ -47,7 +41,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class IntegrationCdcTest extends IntegrationTestBase {
+public abstract class AbstractIntegrationCdcTest extends IntegrationTestBase {
 
   private static final String TEST_DB = "test";
   private static final String TEST_TABLE = "foobar";
@@ -56,15 +50,15 @@ public class IntegrationCdcTest extends IntegrationTestBase {
   @BeforeEach
   public void setup() {
     createTopic(testTopic, TEST_TOPIC_PARTITIONS);
-    catalog.createNamespace(Namespace.of(TEST_DB));
+    ((SupportsNamespaces) catalog).createNamespace(Namespace.of(TEST_DB));
   }
 
   @AfterEach
   public void teardown() {
-    context.stopConnector(connectorName);
+    context.stopKafkaConnector(connectorName);
     deleteTopic(testTopic);
     catalog.dropTable(TableIdentifier.of(TEST_DB, TEST_TABLE));
-    catalog.dropNamespace(Namespace.of(TEST_DB));
+    ((SupportsNamespaces) catalog).dropNamespace(Namespace.of(TEST_DB));
   }
 
   @ParameterizedTest
@@ -126,22 +120,14 @@ public class IntegrationCdcTest extends IntegrationTestBase {
             .config("iceberg.tables.cdcField", "op")
             .config("iceberg.control.commitIntervalMs", 1000)
             .config("iceberg.control.commitTimeoutMs", Integer.MAX_VALUE)
-            .config(
-                "iceberg.catalog." + CatalogUtil.ICEBERG_CATALOG_TYPE,
-                CatalogUtil.ICEBERG_CATALOG_TYPE_REST)
-            .config("iceberg.catalog." + CatalogProperties.URI, "http://iceberg:8181")
-            .config("iceberg.catalog." + S3FileIOProperties.ENDPOINT, "http://minio:9000")
-            .config("iceberg.catalog." + S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
-            .config("iceberg.catalog." + S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
-            .config("iceberg.catalog." + S3FileIOProperties.PATH_STYLE_ACCESS, true)
-            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION)
             .config("iceberg.kafka.auto.offset.reset", "earliest");
+    connectorCatalogProperties().forEach(connectorConfig::config);
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.defaultCommitBranch", branch);
     }
 
-    context.startConnector(connectorConfig);
+    context.startKafkaConnector(connectorConfig);
 
     // start with 3 records, update 1, delete 1. Should be a total of 4 adds and 2 deletes
     // (the update will be 1 add and 1 delete)

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/AbstractIntegrationDynamicTableTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/AbstractIntegrationDynamicTableTest.java
@@ -18,9 +18,6 @@
  */
 package io.tabular.iceberg.connect;
 
-import static io.tabular.iceberg.connect.TestConstants.AWS_ACCESS_KEY;
-import static io.tabular.iceberg.connect.TestConstants.AWS_REGION;
-import static io.tabular.iceberg.connect.TestConstants.AWS_SECRET_KEY;
 import static io.tabular.iceberg.connect.TestEvent.TEST_SCHEMA;
 import static io.tabular.iceberg.connect.TestEvent.TEST_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,13 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.List;
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.aws.AwsClientProperties;
-import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -43,7 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class IntegrationDynamicTableTest extends IntegrationTestBase {
+public abstract class AbstractIntegrationDynamicTableTest extends IntegrationTestBase {
 
   private static final String TEST_DB = "test";
   private static final String TEST_TABLE1 = "tbl1";
@@ -54,16 +48,16 @@ public class IntegrationDynamicTableTest extends IntegrationTestBase {
   @BeforeEach
   public void setup() {
     createTopic(testTopic, TEST_TOPIC_PARTITIONS);
-    catalog.createNamespace(Namespace.of(TEST_DB));
+    ((SupportsNamespaces) catalog).createNamespace(Namespace.of(TEST_DB));
   }
 
   @AfterEach
   public void teardown() {
-    context.stopConnector(connectorName);
+    context.stopKafkaConnector(connectorName);
     deleteTopic(testTopic);
     catalog.dropTable(TableIdentifier.of(TEST_DB, TEST_TABLE1));
     catalog.dropTable(TableIdentifier.of(TEST_DB, TEST_TABLE2));
-    catalog.dropNamespace(Namespace.of(TEST_DB));
+    ((SupportsNamespaces) catalog).dropNamespace(Namespace.of(TEST_DB));
   }
 
   @ParameterizedTest
@@ -104,22 +98,14 @@ public class IntegrationDynamicTableTest extends IntegrationTestBase {
             .config("iceberg.tables.routeField", "payload")
             .config("iceberg.control.commitIntervalMs", 1000)
             .config("iceberg.control.commitTimeoutMs", Integer.MAX_VALUE)
-            .config(
-                "iceberg.catalog." + CatalogUtil.ICEBERG_CATALOG_TYPE,
-                CatalogUtil.ICEBERG_CATALOG_TYPE_REST)
-            .config("iceberg.catalog." + CatalogProperties.URI, "http://iceberg:8181")
-            .config("iceberg.catalog." + S3FileIOProperties.ENDPOINT, "http://minio:9000")
-            .config("iceberg.catalog." + S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
-            .config("iceberg.catalog." + S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
-            .config("iceberg.catalog." + S3FileIOProperties.PATH_STYLE_ACCESS, true)
-            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION)
             .config("iceberg.kafka.auto.offset.reset", "earliest");
+    connectorCatalogProperties().forEach(connectorConfig::config);
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.defaultCommitBranch", branch);
     }
 
-    context.startConnector(connectorConfig);
+    context.startKafkaConnector(connectorConfig);
 
     TestEvent event1 =
         new TestEvent(1, "type1", System.currentTimeMillis(), TEST_DB + "." + TEST_TABLE1);

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/AbstractIntegrationTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/AbstractIntegrationTest.java
@@ -18,9 +18,6 @@
  */
 package io.tabular.iceberg.connect;
 
-import static io.tabular.iceberg.connect.TestConstants.AWS_ACCESS_KEY;
-import static io.tabular.iceberg.connect.TestConstants.AWS_REGION;
-import static io.tabular.iceberg.connect.TestConstants.AWS_SECRET_KEY;
 import static io.tabular.iceberg.connect.TestEvent.TEST_SCHEMA;
 import static io.tabular.iceberg.connect.TestEvent.TEST_SPEC;
 import static java.lang.String.format;
@@ -29,13 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.List;
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.aws.AwsClientProperties;
-import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -44,49 +38,55 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class IntegrationMultiTableTest extends IntegrationTestBase {
+public abstract class AbstractIntegrationTest extends IntegrationTestBase {
 
   private static final String TEST_DB = "test";
-  private static final String TEST_TABLE1 = "foobar1";
-  private static final String TEST_TABLE2 = "foobar2";
-  private static final TableIdentifier TABLE_IDENTIFIER1 = TableIdentifier.of(TEST_DB, TEST_TABLE1);
-  private static final TableIdentifier TABLE_IDENTIFIER2 = TableIdentifier.of(TEST_DB, TEST_TABLE2);
+  private static final String TEST_TABLE = "foobar";
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(TEST_DB, TEST_TABLE);
 
   @BeforeEach
   public void setup() {
     createTopic(testTopic, TEST_TOPIC_PARTITIONS);
-    catalog.createNamespace(Namespace.of(TEST_DB));
+    ((SupportsNamespaces) catalog).createNamespace(Namespace.of(TEST_DB));
   }
 
   @AfterEach
   public void teardown() {
-    context.stopConnector(connectorName);
+    context.stopKafkaConnector(connectorName);
     deleteTopic(testTopic);
-    catalog.dropTable(TableIdentifier.of(TEST_DB, TEST_TABLE1));
-    catalog.dropTable(TableIdentifier.of(TEST_DB, TEST_TABLE2));
-    catalog.dropNamespace(Namespace.of(TEST_DB));
+    catalog.dropTable(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    ((SupportsNamespaces) catalog).dropNamespace(Namespace.of(TEST_DB));
   }
 
   @ParameterizedTest
   @NullSource
   @ValueSource(strings = {"test_branch"})
-  public void testIcebergSink(String branch) {
-    // partitioned table
-    catalog.createTable(TABLE_IDENTIFIER1, TEST_SCHEMA, TEST_SPEC);
-    // unpartitioned table
-    catalog.createTable(TABLE_IDENTIFIER2, TEST_SCHEMA);
+  public void testIcebergSinkPartitionedTable(String branch) {
+    catalog.createTable(TABLE_IDENTIFIER, TEST_SCHEMA, TEST_SPEC);
 
     runTest(branch);
 
-    List<DataFile> files = getDataFiles(TABLE_IDENTIFIER1, branch);
-    assertThat(files).hasSize(1);
+    List<DataFile> files = getDataFiles(TABLE_IDENTIFIER, branch);
+    // partition may involve 1 or 2 workers
+    assertThat(files).hasSizeBetween(1, 2);
     assertEquals(1, files.get(0).recordCount());
-    assertSnapshotProps(TABLE_IDENTIFIER1, branch);
+    assertEquals(1, files.get(1).recordCount());
+    assertSnapshotProps(TABLE_IDENTIFIER, branch);
+  }
 
-    files = getDataFiles(TABLE_IDENTIFIER2, branch);
-    assertThat(files).hasSize(1);
-    assertEquals(1, files.get(0).recordCount());
-    assertSnapshotProps(TABLE_IDENTIFIER2, branch);
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"test_branch"})
+  public void testIcebergSinkUnpartitionedTable(String branch) {
+    catalog.createTable(TABLE_IDENTIFIER, TEST_SCHEMA);
+
+    runTest(branch);
+
+    List<DataFile> files = getDataFiles(TABLE_IDENTIFIER, branch);
+    // may involve 1 or 2 workers
+    assertThat(files).hasSizeBetween(1, 2);
+    assertEquals(2, files.stream().mapToLong(DataFile::recordCount).sum());
+    assertSnapshotProps(TABLE_IDENTIFIER, branch);
   }
 
   private void runTest(String branch) {
@@ -101,38 +101,24 @@ public class IntegrationMultiTableTest extends IntegrationTestBase {
             .config("key.converter.schemas.enable", false)
             .config("value.converter", "org.apache.kafka.connect.json.JsonConverter")
             .config("value.converter.schemas.enable", false)
-            .config(
-                "iceberg.tables",
-                format("%s.%s, %s.%s", TEST_DB, TEST_TABLE1, TEST_DB, TEST_TABLE2))
-            .config("iceberg.tables.routeField", "type")
-            .config(format("iceberg.table.%s.%s.routeRegex", TEST_DB, TEST_TABLE1), "type1")
-            .config(format("iceberg.table.%s.%s.routeRegex", TEST_DB, TEST_TABLE2), "type2")
+            .config("iceberg.tables", format("%s.%s", TEST_DB, TEST_TABLE))
             .config("iceberg.control.commitIntervalMs", 1000)
             .config("iceberg.control.commitTimeoutMs", Integer.MAX_VALUE)
-            .config(
-                "iceberg.catalog." + CatalogUtil.ICEBERG_CATALOG_TYPE,
-                CatalogUtil.ICEBERG_CATALOG_TYPE_REST)
-            .config("iceberg.catalog." + CatalogProperties.URI, "http://iceberg:8181")
-            .config("iceberg.catalog." + S3FileIOProperties.ENDPOINT, "http://minio:9000")
-            .config("iceberg.catalog." + S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
-            .config("iceberg.catalog." + S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
-            .config("iceberg.catalog." + S3FileIOProperties.PATH_STYLE_ACCESS, true)
-            .config("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION)
             .config("iceberg.kafka.auto.offset.reset", "earliest");
+    connectorCatalogProperties().forEach(connectorConfig::config);
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.defaultCommitBranch", branch);
     }
-
-    context.startConnector(connectorConfig);
+    context.startKafkaConnector(connectorConfig);
 
     TestEvent event1 = new TestEvent(1, "type1", System.currentTimeMillis(), "hello world!");
-    TestEvent event2 = new TestEvent(2, "type2", System.currentTimeMillis(), "having fun?");
-    TestEvent event3 = new TestEvent(3, "type3", System.currentTimeMillis(), "ignore me");
+
+    long threeDaysAgo = System.currentTimeMillis() - Duration.ofDays(3).toMillis();
+    TestEvent event2 = new TestEvent(2, "type2", threeDaysAgo, "having fun?");
 
     send(testTopic, event1);
     send(testTopic, event2);
-    send(testTopic, event3);
     flush();
 
     Awaitility.await()
@@ -142,9 +128,7 @@ public class IntegrationMultiTableTest extends IntegrationTestBase {
   }
 
   private void assertSnapshotAdded() {
-    Table table = catalog.loadTable(TABLE_IDENTIFIER1);
-    assertThat(table.snapshots()).hasSize(1);
-    table = catalog.loadTable(TABLE_IDENTIFIER2);
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
     assertThat(table.snapshots()).hasSize(1);
   }
 }

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTestBase.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTestBase.java
@@ -22,7 +22,7 @@ import static io.tabular.iceberg.connect.TestConstants.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -33,10 +33,10 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -46,11 +46,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.services.s3.S3Client;
 
-public class IntegrationTestBase {
+public abstract class IntegrationTestBase {
 
   protected final TestContext context = TestContext.INSTANCE;
   protected S3Client s3;
-  protected RESTCatalog catalog;
+  protected Catalog catalog;
   protected Admin admin;
 
   private KafkaProducer<String, String> producer;
@@ -62,10 +62,10 @@ public class IntegrationTestBase {
 
   @BeforeEach
   public void baseSetup() {
-    s3 = context.initLocalS3Client();
-    catalog = context.initLocalCatalog();
-    producer = context.initLocalProducer();
-    admin = context.initLocalAdmin();
+    s3 = TestContextUtil.initLocalS3Client(context.localMinioPort());
+    catalog = intCatalog();
+    producer = TestContextUtil.initLocalProducer(context.kafkaBootstrapServers());
+    admin = TestContextUtil.initLocalAdmin(context.kafkaBootstrapServers());
 
     this.connectorName = "test_connector-" + UUID.randomUUID();
     this.testTopic = "test-topic-" + UUID.randomUUID();
@@ -74,13 +74,31 @@ public class IntegrationTestBase {
   @AfterEach
   public void baseTeardown() {
     try {
-      catalog.close();
-    } catch (IOException e) {
-      // NO-OP
+      if (catalog instanceof AutoCloseable) {
+        ((AutoCloseable) catalog).close();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
     producer.close();
     admin.close();
     s3.close();
+  }
+
+  protected abstract TestConstants.CatalogType catalogType();
+
+  private Catalog intCatalog() {
+    if (catalogType() == TestConstants.CatalogType.REST) {
+      return context.initRestCatalog();
+    }
+    return null;
+  }
+
+  protected Map<String, Object> connectorCatalogProperties() {
+    if (catalogType() == TestConstants.CatalogType.REST) {
+      return TestContextUtil.connectorRestCatalogProperties();
+    }
+    return Collections.emptyMap();
   }
 
   protected void assertSnapshotProps(TableIdentifier tableIdentifier, String branch) {

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestContext.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestContext.java
@@ -22,31 +22,22 @@ import static io.tabular.iceberg.connect.TestConstants.AWS_ACCESS_KEY;
 import static io.tabular.iceberg.connect.TestConstants.AWS_REGION;
 import static io.tabular.iceberg.connect.TestConstants.AWS_SECRET_KEY;
 import static io.tabular.iceberg.connect.TestConstants.BUCKET;
+import static io.tabular.iceberg.connect.TestContextUtil.MINIO_PORT;
+import static io.tabular.iceberg.connect.TestContextUtil.REST_CATALOG_PORT;
+import static io.tabular.iceberg.connect.TestContextUtil.initLocalS3Client;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.RESTCatalog;
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @SuppressWarnings("rawtypes")
@@ -60,53 +51,20 @@ public class TestContext {
   private final GenericContainer restCatalog;
   private final GenericContainer minio;
 
-  private static final String LOCAL_INSTALL_DIR = "build/install";
-  private static final String KC_PLUGIN_DIR = "/test/kafka-connect";
-
-  private static final String MINIO_IMAGE = "minio/minio";
-  private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:7.4.1";
-  private static final String CONNECT_IMAGE = "confluentinc/cp-kafka-connect:7.4.1";
-  private static final String REST_CATALOG_IMAGE = "tabulario/iceberg-rest:0.6.0";
-
   private TestContext() {
     network = Network.newNetwork();
 
-    minio =
-        new GenericContainer<>(DockerImageName.parse(MINIO_IMAGE))
-            .withNetwork(network)
-            .withNetworkAliases("minio")
-            .withExposedPorts(9000)
-            .withCommand("server /data")
-            .waitingFor(new HttpWaitStrategy().forPort(9000).forPath("/minio/health/ready"));
+    minio = TestContextUtil.minioContainer(network);
 
-    restCatalog =
-        new GenericContainer<>(DockerImageName.parse(REST_CATALOG_IMAGE))
-            .withNetwork(network)
-            .withNetworkAliases("iceberg")
-            .dependsOn(minio)
-            .withExposedPorts(8181)
-            .withEnv("CATALOG_WAREHOUSE", "s3://" + BUCKET + "/warehouse")
-            .withEnv("CATALOG_IO__IMPL", S3FileIO.class.getName())
-            .withEnv("CATALOG_S3_ENDPOINT", "http://minio:9000")
-            .withEnv("CATALOG_S3_ACCESS__KEY__ID", AWS_ACCESS_KEY)
-            .withEnv("CATALOG_S3_SECRET__ACCESS__KEY", AWS_SECRET_KEY)
-            .withEnv("CATALOG_S3_PATH__STYLE__ACCESS", "true")
-            .withEnv("AWS_REGION", AWS_REGION);
+    restCatalog = TestContextUtil.restCatalogContainer(network, minio);
 
-    kafka = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE)).withNetwork(network);
+    kafka = TestContextUtil.kafkaContainer(network);
 
-    kafkaConnect =
-        new KafkaConnectContainer(DockerImageName.parse(CONNECT_IMAGE))
-            .withNetwork(network)
-            .dependsOn(restCatalog, kafka)
-            .withFileSystemBind(LOCAL_INSTALL_DIR, KC_PLUGIN_DIR)
-            .withEnv("CONNECT_PLUGIN_PATH", KC_PLUGIN_DIR)
-            .withEnv("CONNECT_BOOTSTRAP_SERVERS", kafka.getNetworkAliases().get(0) + ":9092")
-            .withEnv("CONNECT_OFFSET_FLUSH_INTERVAL_MS", "500");
+    kafkaConnect = TestContextUtil.kafkaConnectContainer(network, restCatalog, kafka);
 
     Startables.deepStart(Stream.of(minio, restCatalog, kafka, kafkaConnect)).join();
 
-    try (S3Client s3 = initLocalS3Client()) {
+    try (S3Client s3 = initLocalS3Client(localMinioPort())) {
       s3.createBucket(req -> req.bucket(BUCKET));
     }
 
@@ -121,72 +79,37 @@ public class TestContext {
     network.close();
   }
 
-  private int getLocalMinioPort() {
-    return minio.getMappedPort(9000);
+  protected int localMinioPort() {
+    return minio.getMappedPort(MINIO_PORT);
   }
 
-  private int getLocalCatalogPort() {
-    return restCatalog.getMappedPort(8181);
-  }
-
-  private String getLocalBootstrapServers() {
+  protected String kafkaBootstrapServers() {
     return kafka.getBootstrapServers();
   }
 
-  public void startConnector(KafkaConnectContainer.Config config) {
+  protected void startKafkaConnector(KafkaConnectContainer.Config config) {
     kafkaConnect.startConnector(config);
     kafkaConnect.ensureConnectorRunning(config.getName());
   }
 
-  public void stopConnector(String name) {
+  protected void stopKafkaConnector(String name) {
     kafkaConnect.stopConnector(name);
   }
 
-  public S3Client initLocalS3Client() {
-    try {
-      return S3Client.builder()
-          .endpointOverride(new URI("http://localhost:" + getLocalMinioPort()))
-          .region(Region.of(AWS_REGION))
-          .forcePathStyle(true)
-          .credentialsProvider(
-              StaticCredentialsProvider.create(
-                  AwsBasicCredentials.create(AWS_ACCESS_KEY, AWS_SECRET_KEY)))
-          .build();
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public RESTCatalog initLocalCatalog() {
-    String localCatalogUri = "http://localhost:" + getLocalCatalogPort();
+  protected Catalog initRestCatalog() {
+    String localCatalogUri = "http://localhost:" + restCatalog.getMappedPort(REST_CATALOG_PORT);
     RESTCatalog result = new RESTCatalog();
     result.initialize(
         "local",
         ImmutableMap.<String, String>builder()
             .put(CatalogProperties.URI, localCatalogUri)
             .put(CatalogProperties.FILE_IO_IMPL, S3FileIO.class.getName())
-            .put(S3FileIOProperties.ENDPOINT, "http://localhost:" + getLocalMinioPort())
+            .put(S3FileIOProperties.ENDPOINT, "http://localhost:" + localMinioPort())
             .put(S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
             .put(S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
             .put(S3FileIOProperties.PATH_STYLE_ACCESS, "true")
             .put(AwsClientProperties.CLIENT_REGION, AWS_REGION)
             .build());
     return result;
-  }
-
-  public KafkaProducer<String, String> initLocalProducer() {
-    return new KafkaProducer<>(
-        ImmutableMap.of(
-            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-            getLocalBootstrapServers(),
-            ProducerConfig.CLIENT_ID_CONFIG,
-            UUID.randomUUID().toString()),
-        new StringSerializer(),
-        new StringSerializer());
-  }
-
-  public Admin initLocalAdmin() {
-    return Admin.create(
-        ImmutableMap.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getLocalBootstrapServers()));
   }
 }

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestContextUtil.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestContextUtil.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect;
+
+import static io.tabular.iceberg.connect.TestConstants.AWS_ACCESS_KEY;
+import static io.tabular.iceberg.connect.TestConstants.AWS_REGION;
+import static io.tabular.iceberg.connect.TestConstants.AWS_SECRET_KEY;
+import static io.tabular.iceberg.connect.TestConstants.BUCKET;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@SuppressWarnings("rawtypes")
+public final class TestContextUtil {
+  private static final String LOCAL_INSTALL_DIR = "build/install";
+  private static final String KC_PLUGIN_DIR = "/test/kafka-connect";
+  private static final String MINIO_IMAGE = "minio/minio";
+  private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:7.4.1";
+  private static final String CONNECT_IMAGE = "confluentinc/cp-kafka-connect:7.4.1";
+  private static final String REST_CATALOG_IMAGE = "tabulario/iceberg-rest:0.6.0";
+
+  public static final int MINIO_PORT = 9000;
+  public static final int REST_CATALOG_PORT = 8181;
+
+  private TestContextUtil() {}
+
+  static GenericContainer minioContainer(Network network) {
+    return new GenericContainer<>(DockerImageName.parse(MINIO_IMAGE))
+        .withNetwork(network)
+        .withNetworkAliases("minio")
+        .withExposedPorts(MINIO_PORT)
+        .withCommand("server /data")
+        .waitingFor(new HttpWaitStrategy().forPort(MINIO_PORT).forPath("/minio/health/ready"));
+  }
+
+  static KafkaContainer kafkaContainer(Network network) {
+    return new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE)).withNetwork(network);
+  }
+
+  static KafkaConnectContainer kafkaConnectContainer(
+      Network network, GenericContainer catalog, KafkaContainer kafka) {
+    return new KafkaConnectContainer(DockerImageName.parse(CONNECT_IMAGE))
+        .withNetwork(network)
+        .dependsOn(catalog, kafka)
+        .withFileSystemBind(LOCAL_INSTALL_DIR, KC_PLUGIN_DIR)
+        .withEnv("CONNECT_PLUGIN_PATH", KC_PLUGIN_DIR)
+        .withEnv("CONNECT_BOOTSTRAP_SERVERS", kafka.getNetworkAliases().get(0) + ":9092")
+        .withEnv("CONNECT_OFFSET_FLUSH_INTERVAL_MS", "500");
+  }
+
+  static S3Client initLocalS3Client(int mappedPort) {
+    try {
+      return S3Client.builder()
+          .endpointOverride(new URI("http://localhost:" + mappedPort))
+          .region(Region.of(AWS_REGION))
+          .forcePathStyle(true)
+          .credentialsProvider(
+              StaticCredentialsProvider.create(
+                  AwsBasicCredentials.create(AWS_ACCESS_KEY, AWS_SECRET_KEY)))
+          .build();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static KafkaProducer<String, String> initLocalProducer(String bootstrapServers) {
+    return new KafkaProducer<>(
+        ImmutableMap.of(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            bootstrapServers,
+            ProducerConfig.CLIENT_ID_CONFIG,
+            UUID.randomUUID().toString()),
+        new StringSerializer(),
+        new StringSerializer());
+  }
+
+  static Admin initLocalAdmin(String bootstrapServers) {
+    return Admin.create(
+        ImmutableMap.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers));
+  }
+
+  static GenericContainer restCatalogContainer(Network network, GenericContainer minio) {
+    return new GenericContainer<>(DockerImageName.parse(REST_CATALOG_IMAGE))
+        .withNetwork(network)
+        .withNetworkAliases("rest")
+        .dependsOn(minio)
+        .withExposedPorts(REST_CATALOG_PORT)
+        .withEnv("CATALOG_WAREHOUSE", "s3://" + BUCKET + "/warehouse")
+        .withEnv("CATALOG_IO__IMPL", S3FileIO.class.getName())
+        .withEnv("CATALOG_S3_ENDPOINT", "http://minio:" + MINIO_PORT)
+        .withEnv("CATALOG_S3_ACCESS__KEY__ID", AWS_ACCESS_KEY)
+        .withEnv("CATALOG_S3_SECRET__ACCESS__KEY", AWS_SECRET_KEY)
+        .withEnv("CATALOG_S3_PATH__STYLE__ACCESS", "true")
+        .withEnv("AWS_REGION", AWS_REGION);
+  }
+
+  static Map<String, Object> connectorRestCatalogProperties() {
+    return ImmutableMap.<String, Object>builder()
+        .put(
+            "iceberg.catalog." + CatalogUtil.ICEBERG_CATALOG_TYPE,
+            CatalogUtil.ICEBERG_CATALOG_TYPE_REST)
+        .put("iceberg.catalog." + CatalogProperties.URI, "http://rest:" + REST_CATALOG_PORT)
+        .put("iceberg.catalog." + S3FileIOProperties.ENDPOINT, "http://minio:" + MINIO_PORT)
+        .put("iceberg.catalog." + S3FileIOProperties.ACCESS_KEY_ID, AWS_ACCESS_KEY)
+        .put("iceberg.catalog." + S3FileIOProperties.SECRET_ACCESS_KEY, AWS_SECRET_KEY)
+        .put("iceberg.catalog." + S3FileIOProperties.PATH_STYLE_ACCESS, true)
+        .put("iceberg.catalog." + AwsClientProperties.CLIENT_REGION, AWS_REGION)
+        .build();
+  }
+}

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/rest/RESTIntegrationCdcTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/rest/RESTIntegrationCdcTest.java
@@ -16,20 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.tabular.iceberg.connect;
+package io.tabular.iceberg.connect.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.tabular.iceberg.connect.AbstractIntegrationCdcTest;
+import io.tabular.iceberg.connect.TestConstants;
 
-public interface TestConstants {
+public class RESTIntegrationCdcTest extends AbstractIntegrationCdcTest {
 
-  String BUCKET = "bucket";
-  String AWS_ACCESS_KEY = "minioadmin";
-  String AWS_SECRET_KEY = "minioadmin";
-  String AWS_REGION = "us-east-1";
-
-  ObjectMapper MAPPER = new ObjectMapper();
-
-  enum CatalogType {
-    REST,
+  @Override
+  protected TestConstants.CatalogType catalogType() {
+    return TestConstants.CatalogType.REST;
   }
 }

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/rest/RESTIntegrationDynamicTableTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/rest/RESTIntegrationDynamicTableTest.java
@@ -16,20 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.tabular.iceberg.connect;
+package io.tabular.iceberg.connect.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.tabular.iceberg.connect.AbstractIntegrationDynamicTableTest;
+import io.tabular.iceberg.connect.TestConstants;
 
-public interface TestConstants {
+public class RESTIntegrationDynamicTableTest extends AbstractIntegrationDynamicTableTest {
 
-  String BUCKET = "bucket";
-  String AWS_ACCESS_KEY = "minioadmin";
-  String AWS_SECRET_KEY = "minioadmin";
-  String AWS_REGION = "us-east-1";
-
-  ObjectMapper MAPPER = new ObjectMapper();
-
-  enum CatalogType {
-    REST,
+  @Override
+  protected TestConstants.CatalogType catalogType() {
+    return TestConstants.CatalogType.REST;
   }
 }

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/rest/RESTIntegrationMultiTableTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/rest/RESTIntegrationMultiTableTest.java
@@ -16,20 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.tabular.iceberg.connect;
+package io.tabular.iceberg.connect.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.tabular.iceberg.connect.AbstractIntegrationMultiTableTest;
+import io.tabular.iceberg.connect.TestConstants;
 
-public interface TestConstants {
+public class RESTIntegrationMultiTableTest extends AbstractIntegrationMultiTableTest {
 
-  String BUCKET = "bucket";
-  String AWS_ACCESS_KEY = "minioadmin";
-  String AWS_SECRET_KEY = "minioadmin";
-  String AWS_REGION = "us-east-1";
-
-  ObjectMapper MAPPER = new ObjectMapper();
-
-  enum CatalogType {
-    REST,
+  @Override
+  protected TestConstants.CatalogType catalogType() {
+    return TestConstants.CatalogType.REST;
   }
 }

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/rest/RESTIntegrationTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/rest/RESTIntegrationTest.java
@@ -16,20 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.tabular.iceberg.connect;
+package io.tabular.iceberg.connect.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.tabular.iceberg.connect.AbstractIntegrationTest;
+import io.tabular.iceberg.connect.TestConstants;
 
-public interface TestConstants {
+public class RESTIntegrationTest extends AbstractIntegrationTest {
 
-  String BUCKET = "bucket";
-  String AWS_ACCESS_KEY = "minioadmin";
-  String AWS_SECRET_KEY = "minioadmin";
-  String AWS_REGION = "us-east-1";
-
-  ObjectMapper MAPPER = new ObjectMapper();
-
-  enum CatalogType {
-    REST,
+  @Override
+  protected TestConstants.CatalogType catalogType() {
+    return TestConstants.CatalogType.REST;
   }
 }


### PR DESCRIPTION
`TestContext` was a singleton class coupled with REST catalog. 
This is an attempt to make it more generic to plugin other catalog for test.