### PR TITLE
Option to add any missing record fields to the table schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Apache Iceberg Sink Connector for Kafka Connect is a sink connector for writ
 * Exactly-once delivery semantics
 * Multi-table fan-out
 * Row mutations (update/delete rows), upsert mode
-* Message conversion using the Iceberg schema as the source of truth
+* Evolution of table schema to match record schema
 * Field name mapping via Iceberg’s column mapping functionality
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.defaultCommitBranch        | Default branch for commits, main is used if not specified                                                     |
 | iceberg.tables.cdcField                   | Name of the field containing the CDC operation, `I`, `U`, or `D`, default is none                             |
 | iceberg.tables.upsertModeEnabled          | Set to `true` to enable upsert mode, default is `false`                                                       |
+| iceberg.tables.evolveSchemaEnabled        | Set to `true` to add any missing record fields to the table schema, default is `false`                        |
 | iceberg.table.\<table name\>.idColumns    | Comma-separated list of columns that identify a row in the table (primary key)                                |
 | iceberg.table.\<table name\>.routeRegex   | The regex used to match a record's `routeField` to a table                                                    |
 | iceberg.table.\<table name\>.commitBranch | Table-specific branch for commits, use `iceberg.tables.defaultCommitBranch` if not specified                  |

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTest.java
@@ -29,14 +29,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.LongType;
+import org.apache.iceberg.types.Types.StringType;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,7 +102,35 @@ public class IntegrationTest extends IntegrationTestBase {
     assertSnapshotProps(TABLE_IDENTIFIER, branch);
   }
 
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"test_branch"})
+  public void testIcebergSinkSchemaEvolution(String branch) {
+    Schema initialSchema =
+        new Schema(ImmutableList.of(Types.NestedField.required(1, "id", Types.LongType.get())));
+    catalog.createTable(TABLE_IDENTIFIER, initialSchema);
+
+    runTest(branch, ImmutableMap.of("iceberg.tables.evolveSchemaEnabled", "true"));
+
+    List<DataFile> files = getDataFiles(TABLE_IDENTIFIER, branch);
+    // may involve 1 or 2 workers
+    assertThat(files).hasSizeBetween(1, 2);
+    assertEquals(2, files.stream().mapToLong(DataFile::recordCount).sum());
+    assertSnapshotProps(TABLE_IDENTIFIER, branch);
+
+    // check the schema
+    Schema tableSchema = catalog.loadTable(TABLE_IDENTIFIER).schema();
+    assertThat(tableSchema.findField("id").type()).isInstanceOf(LongType.class);
+    assertThat(tableSchema.findField("type").type()).isInstanceOf(StringType.class);
+    assertThat(tableSchema.findField("ts").type()).isInstanceOf(LongType.class);
+    assertThat(tableSchema.findField("payload").type()).isInstanceOf(StringType.class);
+  }
+
   private void runTest(String branch) {
+    runTest(branch, ImmutableMap.of());
+  }
+
+  private void runTest(String branch, Map<String, String> extraConfig) {
     // set offset reset to earliest so we don't miss any test messages
     KafkaConnectContainer.Config connectorConfig =
         new KafkaConnectContainer.Config(connectorName)
@@ -124,6 +159,9 @@ public class IntegrationTest extends IntegrationTestBase {
     if (branch != null) {
       connectorConfig.config("iceberg.tables.defaultCommitBranch", branch);
     }
+
+    extraConfig.forEach(connectorConfig::config);
+
     context.startConnector(connectorConfig);
 
     TestEvent event1 = new TestEvent(1, "type1", System.currentTimeMillis(), "hello world!");

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -71,6 +71,8 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String TABLES_DEFAULT_COMMIT_BRANCH = "iceberg.tables.defaultCommitBranch";
   private static final String TABLES_CDC_FIELD_PROP = "iceberg.tables.cdcField";
   private static final String TABLES_UPSERT_MODE_ENABLED_PROP = "iceberg.tables.upsertModeEnabled";
+  private static final String TABLES_EVOLVE_SCHEMA_ENABLED_PROP =
+      "iceberg.tables.evolveSchemaEnabled";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PROP = "iceberg.control.group.id";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commitIntervalMs";
@@ -140,6 +142,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         false,
         Importance.MEDIUM,
         "Set to true to treat all appends as upserts, false otherwise");
+    configDef.define(
+        TABLES_EVOLVE_SCHEMA_ENABLED_PROP,
+        Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        "Set to true to add any missing record fields to the table schema, false otherwise");
     configDef.define(
         CATALOG_NAME_PROP,
         Type.STRING,
@@ -338,6 +346,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public boolean isUpsertMode() {
     return getBoolean(TABLES_UPSERT_MODE_ENABLED_PROP);
+  }
+
+  public boolean isEvolveSchema() {
+    return getBoolean(TABLES_EVOLVE_SCHEMA_ENABLED_PROP);
   }
 
   public JsonConverter getJsonConverter() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -113,7 +113,7 @@ public class Worker extends Channel {
     }
 
     List<WriterResult> writeResults =
-        writers.values().stream().map(IcebergWriter::complete).collect(toList());
+        writers.values().stream().flatMap(writer -> writer.complete().stream()).collect(toList());
     Map<TopicPartition, Offset> offsets = new HashMap<>(sourceOffsets);
 
     tableExistsMap.clear();

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -92,8 +92,11 @@ public class IcebergWriter implements Closeable {
     Record row = recordConverter.convert(record.value(), updates::add);
 
     if (updates.size() > 0) {
-      SchemaUtils.applySchemaUpdates(table, updates);
+      // complete the current file
       flush();
+      // apply the schema updates, this will refresh the table
+      SchemaUtils.applySchemaUpdates(table, updates);
+      // initialize a new writer with the new schema
       initNewWriter();
     }
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -98,6 +98,8 @@ public class IcebergWriter implements Closeable {
       SchemaUtils.applySchemaUpdates(table, updates);
       // initialize a new writer with the new schema
       initNewWriter();
+      // convert the row again, this time using the new table schema
+      row = recordConverter.convert(record.value(), updates::add);
     }
 
     return row;

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
@@ -19,6 +19,7 @@
 package io.tabular.iceberg.connect.data;
 
 import io.tabular.iceberg.connect.data.SchemaUpdate.AddColumn;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -52,7 +53,7 @@ public class SchemaUtils {
       return;
     }
 
-    Tasks.foreach(updates)
+    Tasks.foreach(Collections.singleton(updates))
         .retry(COMMIT_RETRY_ATTEMPTS)
         .run(notUsed -> commitSchemaUpdates(table, updates));
   }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
@@ -19,6 +19,11 @@
 package io.tabular.iceberg.connect.data;
 
 import io.tabular.iceberg.connect.data.SchemaUpdate.AddColumn;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +33,8 @@ import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.BinaryType;
 import org.apache.iceberg.types.Types.BooleanType;
+import org.apache.iceberg.types.Types.DateType;
+import org.apache.iceberg.types.Types.DecimalType;
 import org.apache.iceberg.types.Types.DoubleType;
 import org.apache.iceberg.types.Types.FloatType;
 import org.apache.iceberg.types.Types.IntegerType;
@@ -37,8 +44,14 @@ import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimeType;
+import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.util.Tasks;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,12 +108,27 @@ public class SchemaUtils {
       case BOOLEAN:
         return BooleanType.get();
       case BYTES:
+        if (valueSchema.name() != null && valueSchema.name().equals(Decimal.LOGICAL_NAME)) {
+          int scale = Integer.parseInt(valueSchema.parameters().get(Decimal.SCALE_FIELD));
+          return DecimalType.of(38, scale);
+        }
         return BinaryType.get();
       case INT8:
       case INT16:
+        return IntegerType.get();
       case INT32:
+        if (valueSchema.name() != null) {
+          if (valueSchema.name().equals(Date.LOGICAL_NAME)) {
+            return DateType.get();
+          } else if (valueSchema.name().equals(Time.LOGICAL_NAME)) {
+            return TimeType.get();
+          }
+        }
         return IntegerType.get();
       case INT64:
+        if (valueSchema.name() != null && valueSchema.name().equals(Timestamp.LOGICAL_NAME)) {
+          return TimestampType.withZone();
+        }
         return LongType.get();
       case FLOAT32:
         return FloatType.get();
@@ -128,6 +156,13 @@ public class SchemaUtils {
   public static Type inferIcebergType(Object value) {
     if (value == null) {
       return StringType.get();
+    } else if (value instanceof String) {
+      return StringType.get();
+    } else if (value instanceof Boolean) {
+      return BooleanType.get();
+    } else if (value instanceof BigDecimal) {
+      BigDecimal bd = (BigDecimal) value;
+      return DecimalType.of(bd.precision(), bd.scale());
     } else if (value instanceof Number) {
       Number num = (Number) value;
       Double d = num.doubleValue();
@@ -136,10 +171,14 @@ public class SchemaUtils {
       } else {
         return DoubleType.get();
       }
-    } else if (value instanceof String) {
-      return StringType.get();
-    } else if (value instanceof Boolean) {
-      return BooleanType.get();
+    } else if (value instanceof LocalDate) {
+      return DateType.get();
+    } else if (value instanceof LocalTime) {
+      return TimeType.get();
+    } else if (value instanceof java.util.Date || value instanceof OffsetDateTime) {
+      return TimestampType.withZone();
+    } else if (value instanceof LocalDateTime) {
+      return TimestampType.withoutZone();
     } else if (value instanceof List) {
       List<?> list = (List<?>) value;
       if (!list.isEmpty()) {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
@@ -48,6 +48,7 @@ public class SchemaUtils {
 
   public static void applySchemaUpdates(Table table, List<AddColumn> updates) {
     if (updates == null || updates.isEmpty()) {
+      // no updates to apply
       return;
     }
 
@@ -57,18 +58,22 @@ public class SchemaUtils {
   }
 
   private static void commitSchemaUpdates(Table table, List<AddColumn> updates) {
+    // get the latest schema in case another process updated it
     table.refresh();
 
+    // filter out columns that have already been added
     List<AddColumn> filteredUpdates =
         updates.stream()
             .filter(update -> !columnExists(table.schema(), update))
             .collect(Collectors.toList());
 
     if (filteredUpdates.isEmpty()) {
+      // no updates to apply
       LOG.info("Schema for table {} already up-to-date", table.name());
       return;
     }
 
+    // apply the updates
     UpdateSchema updateSchema = table.updateSchema();
     filteredUpdates.forEach(
         update -> updateSchema.addColumn(update.parentName(), update.name(), update.type()));

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -77,7 +77,7 @@ public class WorkerTest extends ChannelTestBase {
             ImmutableList.of(),
             StructType.of());
     IcebergWriter writer = mock(IcebergWriter.class);
-    when(writer.complete()).thenReturn(writeResult);
+    when(writer.complete()).thenReturn(ImmutableList.of(writeResult));
 
     IcebergWriterFactory writerFactory = mock(IcebergWriterFactory.class);
     when(writerFactory.createWriter(any())).thenReturn(writer);


### PR DESCRIPTION
This PR introduces a new connector option, `iceberg.tables.evolveSchemaEnabled`. When this is set to true, sink tasks will detect any record fields that are missing from the table during message conversion. Missing columns are then added to the table before the row is written, the row is re-converted using the new schema, and finally the row is written.

All tasks apply schema changes independently, thus each task might attempt the same schema changes. Because of this, multiple attempts are made to update the schema, and the latest schema is checked to see if the changes were applied by another process. This ensures all tasks end up using the same field IDs when writing the data, and the catalog is the source of truth.

Automatic table creation will be added in a follow-up PR.