### PR TITLE
Skip type inference for null value

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordConverter.java
@@ -163,7 +163,7 @@ public class RecordConverter {
           String recordFieldName = recordFieldNameObj.toString();
           NestedField tableField = lookupStructField(recordFieldName, schema, structFieldId);
           if (tableField == null) {
-            if (missingColConsumer != null) {
+            if (missingColConsumer != null && recordFieldValue != null) {
               String parentFieldName =
                   structFieldId < 0 ? null : tableSchema.findColumnName(structFieldId);
               Type type = SchemaUtils.inferIcebergType(recordFieldValue);


### PR DESCRIPTION
This PR skips adding a column during schema evolution if there is no value schema and the value is null. Previously the column would be inferred as a string type.