### PR TITLE
Option to automatically create table if it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.defaultCommitBranch        | Default branch for commits, main is used if not specified                                                     |
 | iceberg.tables.cdcField                   | Name of the field containing the CDC operation, `I`, `U`, or `D`, default is none                             |
 | iceberg.tables.upsertModeEnabled          | Set to `true` to enable upsert mode, default is `false`                                                       |
+| iceberg.tables.autoCreateEnabled          | Set to true to automatically create destination tables, default is `false`                                    |
 | iceberg.tables.evolveSchemaEnabled        | Set to `true` to add any missing record fields to the table schema, default is `false`                        |
 | iceberg.table.\<table name\>.idColumns    | Comma-separated list of columns that identify a row in the table (primary key)                                |
 | iceberg.table.\<table name\>.routeRegex   | The regex used to match a record's `routeField` to a table                                                    |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.defaultCommitBranch        | Default branch for commits, main is used if not specified                                                     |
 | iceberg.tables.cdcField                   | Name of the field containing the CDC operation, `I`, `U`, or `D`, default is none                             |
 | iceberg.tables.upsertModeEnabled          | Set to `true` to enable upsert mode, default is `false`                                                       |
-| iceberg.tables.autoCreateEnabled          | Set to true to automatically create destination tables, default is `false`                                    |
+| iceberg.tables.autoCreateEnabled          | Set to `true` to automatically create destination tables, default is `false`                                  |
 | iceberg.tables.evolveSchemaEnabled        | Set to `true` to add any missing record fields to the table schema, default is `false`                        |
 | iceberg.table.\<table name\>.idColumns    | Comma-separated list of columns that identify a row in the table (primary key)                                |
 | iceberg.table.\<table name\>.routeRegex   | The regex used to match a record's `routeField` to a table                                                    |

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -71,6 +71,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String TABLES_DEFAULT_COMMIT_BRANCH = "iceberg.tables.defaultCommitBranch";
   private static final String TABLES_CDC_FIELD_PROP = "iceberg.tables.cdcField";
   private static final String TABLES_UPSERT_MODE_ENABLED_PROP = "iceberg.tables.upsertModeEnabled";
+  private static final String TABLES_AUTO_CREATE_ENABLED_PROP = "iceberg.tables.autoCreateEnabled";
   private static final String TABLES_EVOLVE_SCHEMA_ENABLED_PROP =
       "iceberg.tables.evolveSchemaEnabled";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
@@ -142,6 +143,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         false,
         Importance.MEDIUM,
         "Set to true to treat all appends as upserts, false otherwise");
+    configDef.define(
+        TABLES_AUTO_CREATE_ENABLED_PROP,
+        Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        "Set to true to automatically create destination tables, false otherwise");
     configDef.define(
         TABLES_EVOLVE_SCHEMA_ENABLED_PROP,
         Type.BOOLEAN,
@@ -346,6 +353,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public boolean isUpsertMode() {
     return getBoolean(TABLES_UPSERT_MODE_ENABLED_PROP);
+  }
+
+  public boolean isAutoCreate() {
+    return getBoolean(TABLES_AUTO_CREATE_ENABLED_PROP);
   }
 
   public boolean isEvolveSchema() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordWriter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.data;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public interface RecordWriter extends Cloneable {
+
+  default void write(SinkRecord record) {}
+
+  default List<WriterResult> complete() {
+    return Collections.emptyList();
+  }
+
+  default void close() {}
+}

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -21,6 +21,7 @@ package io.tabular.iceberg.connect.channel;
 import static io.tabular.iceberg.connect.events.EventTestUtil.createDataFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -80,7 +81,7 @@ public class WorkerTest extends ChannelTestBase {
     when(writer.complete()).thenReturn(ImmutableList.of(writeResult));
 
     IcebergWriterFactory writerFactory = mock(IcebergWriterFactory.class);
-    when(writerFactory.createWriter(any(), any(), any())).thenReturn(writer);
+    when(writerFactory.createWriter(any(), any(), anyBoolean())).thenReturn(writer);
 
     Worker worker = new Worker(catalog, config, clientFactory, writerFactory, context);
     worker.start();

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -80,7 +80,7 @@ public class WorkerTest extends ChannelTestBase {
     when(writer.complete()).thenReturn(ImmutableList.of(writeResult));
 
     IcebergWriterFactory writerFactory = mock(IcebergWriterFactory.class);
-    when(writerFactory.createWriter(any())).thenReturn(writer);
+    when(writerFactory.createWriter(any(), any(), any())).thenReturn(writer);
 
     Worker worker = new Worker(catalog, config, clientFactory, writerFactory, context);
     worker.start();


### PR DESCRIPTION
This PR adds a new config option to enable automatically creating a destination table if it does not exist. The table schema is derived from the record value schema, or if there is no schema, then it is inferred from the record values.