### PR TITLE
Evolve int and float types if needed

### DIFF
--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationCdcTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationCdcTest.java
@@ -24,6 +24,8 @@ import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -66,7 +68,8 @@ public class IntegrationCdcTest extends IntegrationTestBase {
     catalog.createTable(
         TABLE_IDENTIFIER, TEST_SCHEMA, TEST_SPEC, ImmutableMap.of(FORMAT_VERSION, "2"));
 
-    runTest(branch);
+    boolean useSchema = branch == null; // use a schema for one of the tests
+    runTest(branch, useSchema);
 
     List<DataFile> files = dataFiles(TABLE_IDENTIFIER, branch);
     // partition may involve 1 or 2 workers
@@ -87,7 +90,8 @@ public class IntegrationCdcTest extends IntegrationTestBase {
   public void testIcebergSinkUnpartitionedTable(String branch) {
     catalog.createTable(TABLE_IDENTIFIER, TEST_SCHEMA, null, ImmutableMap.of(FORMAT_VERSION, "2"));
 
-    runTest(branch);
+    boolean useSchema = branch == null; // use a schema for one of the tests
+    runTest(branch, useSchema);
 
     List<DataFile> files = dataFiles(TABLE_IDENTIFIER, branch);
     // may involve 1 or 2 workers
@@ -102,7 +106,7 @@ public class IntegrationCdcTest extends IntegrationTestBase {
     assertSnapshotProps(TABLE_IDENTIFIER, branch);
   }
 
-  private void runTest(String branch) {
+  private void runTest(String branch, boolean useSchema) {
     // set offset reset to earliest so we don't miss any test messages
     KafkaConnectContainer.Config connectorConfig =
         new KafkaConnectContainer.Config(connectorName)
@@ -113,16 +117,21 @@ public class IntegrationCdcTest extends IntegrationTestBase {
             .config("key.converter", "org.apache.kafka.connect.json.JsonConverter")
             .config("key.converter.schemas.enable", false)
             .config("value.converter", "org.apache.kafka.connect.json.JsonConverter")
-            .config("value.converter.schemas.enable", false)
+            .config("value.converter.schemas.enable", useSchema)
             .config("iceberg.tables", String.format("%s.%s", TEST_DB, TEST_TABLE))
             .config("iceberg.tables.cdc-field", "op")
             .config("iceberg.control.commit.interval-ms", 1000)
             .config("iceberg.control.commit.timeout-ms", Integer.MAX_VALUE)
             .config("iceberg.kafka.auto.offset.reset", "earliest");
+
     context.connectorCatalogProperties().forEach(connectorConfig::config);
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.default-commit-branch", branch);
+    }
+
+    if (!useSchema) {
+      connectorConfig.config("value.converter.schemas.enable", false);
     }
 
     context.startConnector(connectorConfig);
@@ -130,20 +139,20 @@ public class IntegrationCdcTest extends IntegrationTestBase {
     // start with 3 records, update 1, delete 1. Should be a total of 4 adds and 2 deletes
     // (the update will be 1 add and 1 delete)
 
-    TestEvent event1 = new TestEvent(1, "type1", System.currentTimeMillis(), "hello world!", "I");
-    TestEvent event2 = new TestEvent(2, "type2", System.currentTimeMillis(), "having fun?", "I");
+    TestEvent event1 = new TestEvent(1, "type1", new Date(), "hello world!", "I");
+    TestEvent event2 = new TestEvent(2, "type2", new Date(), "having fun?", "I");
 
-    long threeDaysAgo = System.currentTimeMillis() - Duration.ofDays(3).toMillis();
+    Date threeDaysAgo = Date.from(Instant.now().minus(Duration.ofDays(3)));
     TestEvent event3 = new TestEvent(3, "type3", threeDaysAgo, "hello from the past!", "I");
 
-    TestEvent event4 = new TestEvent(1, "type1", System.currentTimeMillis(), "hello world!", "D");
+    TestEvent event4 = new TestEvent(1, "type1", new Date(), "hello world!", "D");
     TestEvent event5 = new TestEvent(3, "type3", threeDaysAgo, "updated!", "U");
 
-    send(testTopic, event1);
-    send(testTopic, event2);
-    send(testTopic, event3);
-    send(testTopic, event4);
-    send(testTopic, event5);
+    send(testTopic, event1, useSchema);
+    send(testTopic, event2, useSchema);
+    send(testTopic, event3, useSchema);
+    send(testTopic, event4, useSchema);
+    send(testTopic, event5, useSchema);
     flush();
 
     Awaitility.await()

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationDynamicTableTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationDynamicTableTest.java
@@ -23,6 +23,7 @@ import static io.tabular.iceberg.connect.TestEvent.TEST_SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.Date;
 import java.util.List;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Table;
@@ -68,7 +69,8 @@ public class IntegrationDynamicTableTest extends IntegrationTestBase {
     // unpartitioned table
     catalog.createTable(TABLE_IDENTIFIER2, TEST_SCHEMA);
 
-    runTest(branch);
+    boolean useSchema = branch == null; // use a schema for one of the tests
+    runTest(branch, useSchema);
 
     List<DataFile> files = dataFiles(TABLE_IDENTIFIER1, branch);
     assertThat(files).hasSize(1);
@@ -81,7 +83,7 @@ public class IntegrationDynamicTableTest extends IntegrationTestBase {
     assertSnapshotProps(TABLE_IDENTIFIER2, branch);
   }
 
-  private void runTest(String branch) {
+  private void runTest(String branch, boolean useSchema) {
     // set offset reset to earliest so we don't miss any test messages
     KafkaConnectContainer.Config connectorConfig =
         new KafkaConnectContainer.Config(connectorName)
@@ -92,29 +94,32 @@ public class IntegrationDynamicTableTest extends IntegrationTestBase {
             .config("key.converter", "org.apache.kafka.connect.json.JsonConverter")
             .config("key.converter.schemas.enable", false)
             .config("value.converter", "org.apache.kafka.connect.json.JsonConverter")
-            .config("value.converter.schemas.enable", false)
+            .config("value.converter.schemas.enable", useSchema)
             .config("iceberg.tables.dynamic-enabled", true)
             .config("iceberg.tables.route-field", "payload")
             .config("iceberg.control.commit.interval-ms", 1000)
             .config("iceberg.control.commit.timeout-ms", Integer.MAX_VALUE)
             .config("iceberg.kafka.auto.offset.reset", "earliest");
+
     context.connectorCatalogProperties().forEach(connectorConfig::config);
 
     if (branch != null) {
       connectorConfig.config("iceberg.tables.default-commit-branch", branch);
     }
 
+    if (!useSchema) {
+      connectorConfig.config("value.converter.schemas.enable", false);
+    }
+
     context.startConnector(connectorConfig);
 
-    TestEvent event1 =
-        new TestEvent(1, "type1", System.currentTimeMillis(), TEST_DB + "." + TEST_TABLE1);
-    TestEvent event2 =
-        new TestEvent(2, "type2", System.currentTimeMillis(), TEST_DB + "." + TEST_TABLE2);
-    TestEvent event3 = new TestEvent(3, "type3", System.currentTimeMillis(), TEST_DB + ".tbl3");
+    TestEvent event1 = new TestEvent(1, "type1", new Date(), TEST_DB + "." + TEST_TABLE1);
+    TestEvent event2 = new TestEvent(2, "type2", new Date(), TEST_DB + "." + TEST_TABLE2);
+    TestEvent event3 = new TestEvent(3, "type3", new Date(), TEST_DB + ".tbl3");
 
-    send(testTopic, event1);
-    send(testTopic, event2);
-    send(testTopic, event3);
+    send(testTopic, event1, useSchema);
+    send(testTopic, event2, useSchema);
+    send(testTopic, event3, useSchema);
     flush();
 
     Awaitility.await()

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTestBase.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTestBase.java
@@ -18,10 +18,8 @@
  */
 package io.tabular.iceberg.connect;
 
-import static io.tabular.iceberg.connect.TestConstants.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -131,13 +129,9 @@ public class IntegrationTestBase {
     }
   }
 
-  protected void send(String topicName, TestEvent event) {
-    try {
-      String eventStr = MAPPER.writeValueAsString(event);
-      producer.send(new ProducerRecord<>(topicName, Long.toString(event.getId()), eventStr));
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+  protected void send(String topicName, TestEvent event, boolean useSchema) {
+    String eventStr = event.serialize(useSchema);
+    producer.send(new ProducerRecord<>(topicName, Long.toString(event.id()), eventStr));
   }
 
   protected void flush() {

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestEvent.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestEvent.java
@@ -18,13 +18,25 @@
  */
 package io.tabular.iceberg.connect;
 
+import static io.tabular.iceberg.connect.TestConstants.MAPPER;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Date;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Types;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.storage.ConverterConfig;
+import org.apache.kafka.connect.storage.ConverterType;
 
-// JavaBean-style for serialization
 public class TestEvent {
 
   public static final Schema TEST_SCHEMA =
@@ -36,20 +48,35 @@ public class TestEvent {
               Types.NestedField.required(4, "payload", Types.StringType.get())),
           ImmutableSet.of(1));
 
+  public static final org.apache.kafka.connect.data.Schema TEST_CONNECT_SCHEMA =
+      SchemaBuilder.struct()
+          .field("id", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+          .field("type", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+          .field("ts", Timestamp.SCHEMA)
+          .field("payload", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+          .field("op", org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA);
+
   public static final PartitionSpec TEST_SPEC =
       PartitionSpec.builderFor(TEST_SCHEMA).day("ts").build();
 
+  private static final JsonConverter JSON_CONVERTER = new JsonConverter();
+
+  static {
+    JSON_CONVERTER.configure(
+        ImmutableMap.of(ConverterConfig.TYPE_CONFIG, ConverterType.VALUE.getName()));
+  }
+
   private final long id;
   private final String type;
-  private final long ts;
+  private final Date ts;
   private final String payload;
   private final String op;
 
-  public TestEvent(long id, String type, long ts, String payload) {
+  public TestEvent(long id, String type, Date ts, String payload) {
     this(id, type, ts, payload, null);
   }
 
-  public TestEvent(long id, String type, long ts, String payload, String op) {
+  public TestEvent(long id, String type, Date ts, String payload, String op) {
     this.id = id;
     this.type = type;
     this.ts = ts;
@@ -57,23 +84,47 @@ public class TestEvent {
     this.op = op;
   }
 
-  public long getId() {
+  public long id() {
     return id;
   }
 
-  public String getType() {
+  public String type() {
     return type;
   }
 
-  public long getTs() {
+  public Date ts() {
     return ts;
   }
 
-  public String getPayload() {
+  public String payload() {
     return payload;
   }
 
-  public String getOp() {
+  public String op() {
     return op;
+  }
+
+  protected String serialize(boolean useSchema) {
+    try {
+      Struct value =
+          new Struct(TEST_CONNECT_SCHEMA)
+              .put("id", id)
+              .put("type", type)
+              .put("ts", ts)
+              .put("payload", payload)
+              .put("op", op);
+
+      String convertMethod =
+          useSchema ? "convertToJsonWithEnvelope" : "convertToJsonWithoutEnvelope";
+      JsonNode json =
+          DynMethods.builder(convertMethod)
+              .hiddenImpl(
+                  JsonConverter.class, org.apache.kafka.connect.data.Schema.class, Object.class)
+              .build(JSON_CONVERTER)
+              .invoke(TestEvent.TEST_CONNECT_SCHEMA, value);
+      return MAPPER.writeValueAsString(json);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -19,7 +19,6 @@
 package io.tabular.iceberg.connect.data;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
-import io.tabular.iceberg.connect.data.SchemaUpdate.AddColumn;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
@@ -83,10 +82,10 @@ public class IcebergWriter implements RecordWriter {
       return recordConverter.convert(record.value());
     }
 
-    List<AddColumn> updates = Lists.newArrayList();
+    List<SchemaUpdate> updates = Lists.newArrayList();
     Record row = recordConverter.convert(record.value(), updates::add);
 
-    if (updates.size() > 0) {
+    if (!updates.isEmpty()) {
       // complete the current file
       flush();
       // apply the schema updates, this will refresh the table

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordConverter.java
@@ -169,6 +169,8 @@ public class RecordConverter {
           String recordFieldName = recordFieldNameObj.toString();
           NestedField tableField = lookupStructField(recordFieldName, schema, structFieldId);
           if (tableField == null) {
+            // add the column if schema evolution is on, otherwise skip the value,
+            // skip the add column if the value is null as we can't infer the type
             if (schemaUpdateConsumer != null && recordFieldValue != null) {
               String parentFieldName =
                   structFieldId < 0 ? null : tableSchema.findColumnName(structFieldId);
@@ -201,6 +203,7 @@ public class RecordConverter {
             recordField -> {
               NestedField tableField = lookupStructField(recordField.name(), schema, structFieldId);
               if (tableField == null) {
+                // add the column if schema evolution is on, otherwise skip the value
                 if (schemaUpdateConsumer != null) {
                   String parentFieldName =
                       structFieldId < 0 ? null : tableSchema.findColumnName(structFieldId);
@@ -210,7 +213,8 @@ public class RecordConverter {
                 }
               } else {
                 PrimitiveType evolveDataType =
-                    SchemaUtils.evolveDataType(tableField.type(), recordField.schema());
+                    SchemaUtils.needsDataTypeUpdate(tableField.type(), recordField.schema());
+                // update the type if needed and schema evolution is on, otherwise set the value
                 if (evolveDataType != null && schemaUpdateConsumer != null) {
                   String fieldName = tableSchema.findColumnName(tableField.fieldId());
                   schemaUpdateConsumer.accept(new TypeUpdate(fieldName, evolveDataType));

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUpdate.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUpdate.java
@@ -19,10 +19,11 @@
 package io.tabular.iceberg.connect.data;
 
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Type.PrimitiveType;
 
 public class SchemaUpdate {
 
-  public static class AddColumn {
+  public static class AddColumn extends SchemaUpdate {
     private final String parentName;
     private final String name;
     private final Type type;
@@ -42,6 +43,24 @@ public class SchemaUpdate {
     }
 
     public Type type() {
+      return type;
+    }
+  }
+
+  public static class TypeUpdate extends SchemaUpdate {
+    private final String name;
+    private final PrimitiveType type;
+
+    public TypeUpdate(String name, PrimitiveType type) {
+      this.name = name;
+      this.type = type;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public PrimitiveType type() {
       return type;
     }
   }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.BinaryType;
+import org.apache.iceberg.types.Types.DateType;
 import org.apache.iceberg.types.Types.DecimalType;
 import org.apache.iceberg.types.Types.DoubleType;
 import org.apache.iceberg.types.Types.FloatType;
@@ -63,10 +64,14 @@ import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimeType;
 import org.apache.iceberg.types.Types.TimestampType;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.storage.ConverterConfig;
@@ -120,13 +125,13 @@ public class RecordConverterTest {
       SchemaBuilder.struct()
           .field("i", Schema.INT32_SCHEMA)
           .field("l", Schema.INT64_SCHEMA)
-          .field("d", Schema.STRING_SCHEMA)
-          .field("t", Schema.STRING_SCHEMA)
-          .field("ts", Schema.STRING_SCHEMA)
-          .field("tsz", Schema.STRING_SCHEMA)
+          .field("d", org.apache.kafka.connect.data.Date.SCHEMA)
+          .field("t", Time.SCHEMA)
+          .field("ts", Timestamp.SCHEMA)
+          .field("tsz", Timestamp.SCHEMA)
           .field("fl", Schema.FLOAT32_SCHEMA)
           .field("do", Schema.FLOAT64_SCHEMA)
-          .field("dec", Schema.STRING_SCHEMA)
+          .field("dec", Decimal.schema(2))
           .field("s", Schema.STRING_SCHEMA)
           .field("u", Schema.STRING_SCHEMA)
           .field("f", Schema.BYTES_SCHEMA)
@@ -455,13 +460,13 @@ public class RecordConverterTest {
 
     assertThat(newColMap.get("i").type()).isInstanceOf(IntegerType.class);
     assertThat(newColMap.get("l").type()).isInstanceOf(LongType.class);
-    assertThat(newColMap.get("d").type()).isInstanceOf(StringType.class);
-    assertThat(newColMap.get("t").type()).isInstanceOf(StringType.class);
-    assertThat(newColMap.get("ts").type()).isInstanceOf(StringType.class);
-    assertThat(newColMap.get("tsz").type()).isInstanceOf(StringType.class);
+    assertThat(newColMap.get("d").type()).isInstanceOf(DateType.class);
+    assertThat(newColMap.get("t").type()).isInstanceOf(TimeType.class);
+    assertThat(newColMap.get("ts").type()).isInstanceOf(TimestampType.class);
+    assertThat(newColMap.get("tsz").type()).isInstanceOf(TimestampType.class);
     assertThat(newColMap.get("fl").type()).isInstanceOf(FloatType.class);
     assertThat(newColMap.get("do").type()).isInstanceOf(DoubleType.class);
-    assertThat(newColMap.get("dec").type()).isInstanceOf(StringType.class);
+    assertThat(newColMap.get("dec").type()).isInstanceOf(DecimalType.class);
     assertThat(newColMap.get("s").type()).isInstanceOf(StringType.class);
     assertThat(newColMap.get("u").type()).isInstanceOf(StringType.class);
     assertThat(newColMap.get("f").type()).isInstanceOf(BinaryType.class);
@@ -555,13 +560,13 @@ public class RecordConverterTest {
     assertThat(addedType.fields()).hasSize(15);
     assertThat(addedType.field("i").type()).isInstanceOf(IntegerType.class);
     assertThat(addedType.field("l").type()).isInstanceOf(LongType.class);
-    assertThat(addedType.field("d").type()).isInstanceOf(StringType.class);
-    assertThat(addedType.field("t").type()).isInstanceOf(StringType.class);
-    assertThat(addedType.field("ts").type()).isInstanceOf(StringType.class);
-    assertThat(addedType.field("tsz").type()).isInstanceOf(StringType.class);
+    assertThat(addedType.field("d").type()).isInstanceOf(DateType.class);
+    assertThat(addedType.field("t").type()).isInstanceOf(TimeType.class);
+    assertThat(addedType.field("ts").type()).isInstanceOf(TimestampType.class);
+    assertThat(addedType.field("tsz").type()).isInstanceOf(TimestampType.class);
     assertThat(addedType.field("fl").type()).isInstanceOf(FloatType.class);
     assertThat(addedType.field("do").type()).isInstanceOf(DoubleType.class);
-    assertThat(addedType.field("dec").type()).isInstanceOf(StringType.class);
+    assertThat(addedType.field("dec").type()).isInstanceOf(DecimalType.class);
     assertThat(addedType.field("s").type()).isInstanceOf(StringType.class);
     assertThat(addedType.field("u").type()).isInstanceOf(StringType.class);
     assertThat(addedType.field("f").type()).isInstanceOf(BinaryType.class);
@@ -598,13 +603,13 @@ public class RecordConverterTest {
     return new Struct(CONNECT_SCHEMA)
         .put("i", 1)
         .put("l", 2L)
-        .put("d", DATE_VAL.toString())
-        .put("t", TIME_VAL.toString())
-        .put("ts", TS_VAL.toString())
-        .put("tsz", TSZ_VAL.toString())
+        .put("d", new Date(DATE_VAL.toEpochDay() * 24 * 60 * 60 * 1000L))
+        .put("t", new Date(TIME_VAL.toNanoOfDay() / 1_000_000))
+        .put("ts", Date.from(TS_VAL.atZone(ZoneOffset.UTC).toInstant()))
+        .put("tsz", Date.from(TSZ_VAL.toInstant()))
         .put("fl", 1.1f)
         .put("do", 2.2d)
-        .put("dec", DEC_VAL.toString())
+        .put("dec", DEC_VAL)
         .put("s", STR_VAL)
         .put("u", UUID_VAL.toString())
         .put("f", BYTES_VAL.array())


### PR DESCRIPTION
This PR adds data type evolution for int -> long and float -> double. This is only used for values with schemas, as without a schema the inferred types are never int or float.