### PR TITLE
Add record key to Debezium CDC metadata

### DIFF
--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
@@ -27,4 +27,5 @@ public interface CdcConstants {
   String COL_CDC_OP = "_cdc_op";
   String COL_CDC_TS = "_cdc_ts";
   String COL_CDC_TABLE = "_cdc_table";
+  String COL_CDC_KEY = "_cdc_key";
 }


### PR DESCRIPTION
This PR adds the record key to the CDC metadata in the Debezium SMT. The record key in Debezium is the primary key by default, so this can be used for merges/deltas.