### PR TITLE
Add support for dropping columns during schema evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.upsert-mode-enabled         | Set to `true` to enable upsert mode, default is `false`                                                       |
 | iceberg.tables.auto-create-enabled         | Set to `true` to automatically create destination tables, default is `false`                                  |
 | iceberg.tables.evolve-schema-enabled       | Set to `true` to add any missing record fields to the table schema, default is `false`                        |
+| iceberg.tables.drop-col-enabled            | Set to `true` to enable dropping of columns during schema evolution, default is `false`                       |
 | iceberg.table.\<table name\>.id-columns    | Comma-separated list of columns that identify a row in the table (primary key)                                |
 | iceberg.table.\<table name\>.route-regex   | The regex used to match a record's `routeField` to a table                                                    |
 | iceberg.table.\<table name\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                |

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -159,6 +159,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         Importance.MEDIUM,
         "Set to true to add any missing record fields to the table schema, false otherwise");
     configDef.define(
+        TABLES_DROP_COL_ENABLED_PROP,
+        Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        "Set to true to enable dropping of columns during schema evolution, false otherwise");
+    configDef.define(
         CATALOG_NAME_PROP,
         Type.STRING,
         DEFAULT_CATALOG_NAME,

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -76,6 +76,7 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.auto-create-enabled";
   private static final String TABLES_EVOLVE_SCHEMA_ENABLED_PROP =
       "iceberg.tables.evolve-schema-enabled";
+  private static final String TABLES_DROP_COL_ENABLED_PROP = "iceberg.tables.drop-col-enabled";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PROP = "iceberg.control.group-id";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -361,6 +362,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public boolean evolveSchemaEnabled() {
     return getBoolean(TABLES_EVOLVE_SCHEMA_ENABLED_PROP);
+  }
+
+  public boolean dropColEnabled() {
+    return getBoolean(TABLES_DROP_COL_ENABLED_PROP);
   }
 
   public JsonConverter jsonConverter() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -89,7 +89,7 @@ public class IcebergWriter implements RecordWriter {
       // complete the current file
       flush();
       // apply the schema updates, this will refresh the table
-      SchemaUtils.applySchemaUpdates(table, updates);
+      SchemaUtils.applySchemaUpdates(table, updates, config.dropColEnabled());
       // initialize a new writer with the new schema
       initNewWriter();
       // convert the row again, this time using the new table schema

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUpdate.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUpdate.java
@@ -47,11 +47,11 @@ public class SchemaUpdate {
     }
   }
 
-  public static class TypeUpdate extends SchemaUpdate {
+  public static class UpdateType extends SchemaUpdate {
     private final String name;
     private final PrimitiveType type;
 
-    public TypeUpdate(String name, PrimitiveType type) {
+    public UpdateType(String name, PrimitiveType type) {
       this.name = name;
       this.type = type;
     }
@@ -62,6 +62,18 @@ public class SchemaUpdate {
 
     public PrimitiveType type() {
       return type;
+    }
+  }
+
+  public static class DropColumn extends SchemaUpdate {
+    private final String name;
+
+    public DropColumn(String name) {
+      this.name = name;
+    }
+
+    public String name() {
+      return name;
     }
   }
 }


### PR DESCRIPTION
This PR adds a config option to allow dropping columns during schema evolution. Similar to data type updates, this is only supported when using records with a value schema.