### PR TITLE
Config to set target in Debezium SMT

### DIFF
--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -33,21 +33,17 @@ It will promote the `data` element fields to top level and add the following met
 
 ## Configuration
 
-The SMT currently has no configuration. It can be used with the sink's CDC feature, e.g.
-```
-"iceberg.tables.cdcField": "_cdc_op",
-```
+The SMT currently has no configuration.
 
 # DebeziumTransform
 _(Experimental)_
 
 The `DebeziumTransform` SMT transforms a Debezium formatted message for use by the sink's CDC feature.
 It will promote the `before` or `after` element fields to top level and add the following metadata fields:
-`_cdc_op`, `_cdc_ts`, and `_cdc_table`.
+`_cdc_op`, `_cdc_ts`, `_cdc_table`, `_cdc_key`, and `_cdc_target`.
 
 ## Configuration
 
-The SMT currently has no configuration. It can be used with the sink's CDC feature, e.g.
-```
-"iceberg.tables.cdcField": "_cdc_op",
-```
+| Property            | Description                                                                       |
+|---------------------|-----------------------------------------------------------------------------------|
+| cdc.target.pattern  | Pattern to use for setting the CDC target field value, default is `{db}.{table}`  |

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
@@ -27,5 +27,6 @@ public interface CdcConstants {
   String COL_CDC_OP = "_cdc_op";
   String COL_CDC_TS = "_cdc_ts";
   String COL_CDC_TABLE = "_cdc_table";
+  String COL_CDC_TARGET = "_cdc_target";
   String COL_CDC_KEY = "_cdc_key";
 }

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CopyValue.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CopyValue.java
@@ -19,7 +19,6 @@
 package io.tabular.iceberg.connect.transforms;
 
 import java.util.Map;
-import jdk.jfr.Experimental;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
@@ -35,27 +34,17 @@ import org.apache.kafka.connect.transforms.util.Requirements;
 import org.apache.kafka.connect.transforms.util.SchemaUtil;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
-@Experimental
 public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> {
 
-  private interface ConfigName {
-
-    String SOURCE_FIELD = "source.field";
-    String TARGET_FIELD = "target.field";
-  }
+  private static final String SOURCE_FIELD = "source.field";
+  private static final String TARGET_FIELD = "target.field";
 
   public static final ConfigDef CONFIG_DEF =
       new ConfigDef()
           .define(
-              ConfigName.SOURCE_FIELD,
-              ConfigDef.Type.STRING,
-              ConfigDef.Importance.HIGH,
-              "Source field name.")
+              SOURCE_FIELD, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, "Source field name.")
           .define(
-              ConfigName.TARGET_FIELD,
-              ConfigDef.Type.STRING,
-              ConfigDef.Importance.HIGH,
-              "Target field name.");
+              TARGET_FIELD, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, "Target field name.");
 
   private String sourceField;
   private String targetField;
@@ -64,8 +53,8 @@ public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> 
   @Override
   public void configure(Map<String, ?> props) {
     SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
-    sourceField = config.getString(ConfigName.SOURCE_FIELD);
-    targetField = config.getString(ConfigName.TARGET_FIELD);
+    sourceField = config.getString(SOURCE_FIELD);
+    targetField = config.getString(TARGET_FIELD);
     schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
   }
 

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/DmsTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/DmsTransform.java
@@ -19,7 +19,6 @@
 package io.tabular.iceberg.connect.transforms;
 
 import java.util.Map;
-import jdk.jfr.Experimental;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -28,7 +27,6 @@ import org.apache.kafka.connect.transforms.util.Requirements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Experimental
 public class DmsTransform<R extends ConnectRecord<R>> implements Transformation<R> {
 
   private static final Logger LOG = LoggerFactory.getLogger(DmsTransform.class.getName());

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DebeziumTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DebeziumTransformTest.java
@@ -73,6 +73,8 @@ public class DebeziumTransformTest {
   @SuppressWarnings("unchecked")
   public void testDebeziumTransformSchemaless() {
     try (DebeziumTransform<SinkRecord> smt = new DebeziumTransform<>()) {
+      smt.configure(ImmutableMap.of("cdc.target.pattern", "{db}_x.{table}_x"));
+
       Map<String, Object> event = createDebeziumEventMap("u");
       Map<String, Object> key = ImmutableMap.of("account_id", 1L);
       SinkRecord record = new SinkRecord("topic", 0, null, key, null, event, 0);
@@ -83,6 +85,7 @@ public class DebeziumTransformTest {
 
       assertThat(value.get("account_id")).isEqualTo(1);
       assertThat(value.get("_cdc_table")).isEqualTo("schema.tbl");
+      assertThat(value.get("_cdc_target")).isEqualTo("schema_x.tbl_x");
       assertThat(value.get("_cdc_op")).isEqualTo("U");
       assertThat(value.get("_cdc_key")).isInstanceOf(Map.class);
     }
@@ -91,6 +94,8 @@ public class DebeziumTransformTest {
   @Test
   public void testDebeziumTransformWithSchema() {
     try (DebeziumTransform<SinkRecord> smt = new DebeziumTransform<>()) {
+      smt.configure(ImmutableMap.of("cdc.target.pattern", "{db}_x.{table}_x"));
+
       Struct event = createDebeziumEventStruct("u");
       Struct key = new Struct(KEY_SCHEMA).put("account_id", 1L);
       SinkRecord record = new SinkRecord("topic", 0, KEY_SCHEMA, key, VALUE_SCHEMA, event, 0);
@@ -101,6 +106,7 @@ public class DebeziumTransformTest {
 
       assertThat(value.get("account_id")).isEqualTo(1L);
       assertThat(value.get("_cdc_table")).isEqualTo("schema.tbl");
+      assertThat(value.get("_cdc_target")).isEqualTo("schema_x.tbl_x");
       assertThat(value.get("_cdc_op")).isEqualTo("U");
       assertThat(value.get("_cdc_key")).isInstanceOf(Struct.class);
     }


### PR DESCRIPTION
This PR adds an new `cdc.target.pattern` configuration that allows setting a simple pattern to populate a target metadata field. This could be useful to generate a destination db/table name that is different from the source.