### PR TITLE
Respect optional/required in table create and schema evolution

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUpdate.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUpdate.java
@@ -47,11 +47,11 @@ public class SchemaUpdate {
     }
   }
 
-  public static class TypeUpdate extends SchemaUpdate {
+  public static class UpdateType extends SchemaUpdate {
     private final String name;
     private final PrimitiveType type;
 
-    public TypeUpdate(String name, PrimitiveType type) {
+    public UpdateType(String name, PrimitiveType type) {
       this.name = name;
       this.type = type;
     }
@@ -62,6 +62,18 @@ public class SchemaUpdate {
 
     public PrimitiveType type() {
       return type;
+    }
+  }
+
+  public static class MakeOptional extends SchemaUpdate {
+    private final String name;
+
+    public MakeOptional(String name) {
+      this.name = name;
+    }
+
+    public String name() {
+      return name;
     }
   }
 }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
@@ -256,7 +256,7 @@ public class SchemaUtils {
           return DoubleType.get();
         case ARRAY:
           Type elementType = toIcebergType(valueSchema.valueSchema());
-          if (valueSchema.isOptional()) {
+          if (valueSchema.valueSchema().isOptional()) {
             return ListType.ofOptional(nextId(), elementType);
           } else {
             return ListType.ofRequired(nextId(), elementType);
@@ -264,7 +264,7 @@ public class SchemaUtils {
         case MAP:
           Type keyType = toIcebergType(valueSchema.keySchema());
           Type valueType = toIcebergType(valueSchema.valueSchema());
-          if (valueSchema.isOptional()) {
+          if (valueSchema.valueSchema().isOptional()) {
             return MapType.ofOptional(nextId(), nextId(), keyType, valueType);
           } else {
             return MapType.ofRequired(nextId(), nextId(), keyType, valueType);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
@@ -21,7 +21,8 @@ package io.tabular.iceberg.connect.data;
 import static java.util.stream.Collectors.toList;
 
 import io.tabular.iceberg.connect.data.SchemaUpdate.AddColumn;
-import io.tabular.iceberg.connect.data.SchemaUpdate.TypeUpdate;
+import io.tabular.iceberg.connect.data.SchemaUpdate.MakeOptional;
+import io.tabular.iceberg.connect.data.SchemaUpdate.UpdateType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -104,14 +105,22 @@ public class SchemaUtils {
             .collect(toList());
 
     // filter out columns that have the updated type
-    List<TypeUpdate> typeUpdates =
+    List<UpdateType> updateTypes =
         updates.stream()
-            .filter(update -> update instanceof TypeUpdate)
-            .map(update -> (TypeUpdate) update)
-            .filter(typeUpdate -> !typeMatches(table.schema(), typeUpdate))
+            .filter(update -> update instanceof UpdateType)
+            .map(update -> (UpdateType) update)
+            .filter(updateType -> !typeMatches(table.schema(), updateType))
             .collect(toList());
 
-    if (addColumns.isEmpty() && typeUpdates.isEmpty()) {
+    // filter out columns that have already been made optional
+    List<MakeOptional> makeOptionals =
+        updates.stream()
+            .filter(update -> update instanceof MakeOptional)
+            .map(update -> (MakeOptional) update)
+            .filter(makeOptional -> !isOptional(table.schema(), makeOptional))
+            .collect(toList());
+
+    if (addColumns.isEmpty() && updateTypes.isEmpty() && makeOptionals.isEmpty()) {
       // no updates to apply
       LOG.info("Schema for table {} already up-to-date", table.name());
       return;
@@ -121,7 +130,8 @@ public class SchemaUtils {
     UpdateSchema updateSchema = table.updateSchema();
     addColumns.forEach(
         update -> updateSchema.addColumn(update.parentName(), update.name(), update.type()));
-    typeUpdates.forEach(update -> updateSchema.updateColumn(update.name(), update.type()));
+    updateTypes.forEach(update -> updateSchema.updateColumn(update.name(), update.type()));
+    makeOptionals.forEach(update -> updateSchema.makeColumnOptional(update.name()));
     updateSchema.commit();
     LOG.info("Schema for table {} updated with new columns", table.name());
   }
@@ -134,8 +144,12 @@ public class SchemaUtils {
     return struct.field(update.name()) != null;
   }
 
-  private static boolean typeMatches(org.apache.iceberg.Schema schema, TypeUpdate update) {
+  private static boolean typeMatches(org.apache.iceberg.Schema schema, UpdateType update) {
     return schema.findType(update.name()).typeId() == update.type().typeId();
+  }
+
+  private static boolean isOptional(org.apache.iceberg.Schema schema, MakeOptional update) {
+    return schema.findField(update.name()).isOptional();
   }
 
   public static PartitionSpec createPartitionSpec(
@@ -242,18 +256,29 @@ public class SchemaUtils {
           return DoubleType.get();
         case ARRAY:
           Type elementType = toIcebergType(valueSchema.valueSchema());
-          return ListType.ofOptional(nextId(), elementType);
+          if (valueSchema.isOptional()) {
+            return ListType.ofOptional(nextId(), elementType);
+          } else {
+            return ListType.ofRequired(nextId(), elementType);
+          }
         case MAP:
           Type keyType = toIcebergType(valueSchema.keySchema());
           Type valueType = toIcebergType(valueSchema.valueSchema());
-          return MapType.ofOptional(nextId(), nextId(), keyType, valueType);
+          if (valueSchema.isOptional()) {
+            return MapType.ofOptional(nextId(), nextId(), keyType, valueType);
+          } else {
+            return MapType.ofRequired(nextId(), nextId(), keyType, valueType);
+          }
         case STRUCT:
           List<NestedField> structFields =
               valueSchema.fields().stream()
                   .map(
                       field ->
-                          NestedField.optional(
-                              nextId(), field.name(), toIcebergType(field.schema())))
+                          NestedField.of(
+                              nextId(),
+                              field.schema().isOptional(),
+                              field.name(),
+                              toIcebergType(field.schema())))
                   .collect(toList());
           return StructType.of(structFields);
         case STRING:

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.tabular.iceberg.connect.data.SchemaUpdate.AddColumn;
-import io.tabular.iceberg.connect.data.SchemaUpdate.TypeUpdate;
+import io.tabular.iceberg.connect.data.SchemaUpdate.UpdateType;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -492,12 +492,12 @@ public class RecordConverterTest {
 
     List<SchemaUpdate> updates = Lists.newArrayList();
     converter.convert(data, updates::add);
-    List<TypeUpdate> addCols =
-        updates.stream().map(update -> (TypeUpdate) update).collect(toList());
+    List<UpdateType> addCols =
+        updates.stream().map(update -> (UpdateType) update).collect(toList());
 
     assertThat(addCols).hasSize(2);
 
-    Map<String, TypeUpdate> updateMap = Maps.newHashMap();
+    Map<String, UpdateType> updateMap = Maps.newHashMap();
     addCols.forEach(update -> updateMap.put(update.name(), update));
 
     assertThat(updateMap.get("ii").type()).isInstanceOf(LongType.class);
@@ -529,12 +529,12 @@ public class RecordConverterTest {
 
     List<SchemaUpdate> updates = Lists.newArrayList();
     converter.convert(data, updates::add);
-    List<TypeUpdate> addCols =
-        updates.stream().map(update -> (TypeUpdate) update).collect(toList());
+    List<UpdateType> addCols =
+        updates.stream().map(update -> (UpdateType) update).collect(toList());
 
     assertThat(addCols).hasSize(2);
 
-    Map<String, TypeUpdate> updateMap = Maps.newHashMap();
+    Map<String, UpdateType> updateMap = Maps.newHashMap();
     addCols.forEach(update -> updateMap.put(update.name(), update));
 
     assertThat(updateMap.get("st.ii").type()).isInstanceOf(LongType.class);

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/SchemaUtilsTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/SchemaUtilsTest.java
@@ -29,7 +29,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.data.SchemaUpdate.AddColumn;
-import io.tabular.iceberg.connect.data.SchemaUpdate.TypeUpdate;
+import io.tabular.iceberg.connect.data.SchemaUpdate.MakeOptional;
+import io.tabular.iceberg.connect.data.SchemaUpdate.UpdateType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -92,8 +93,9 @@ public class SchemaUtilsTest {
     List<SchemaUpdate> updates =
         ImmutableList.of(
             new AddColumn(null, "i", IntegerType.get()),
-            new TypeUpdate("i", IntegerType.get()),
-            new TypeUpdate("f", DoubleType.get()),
+            new UpdateType("i", IntegerType.get()),
+            new MakeOptional("i"),
+            new UpdateType("f", DoubleType.get()),
             new AddColumn(null, "s", StringType.get()));
 
     SchemaUtils.applySchemaUpdates(table, updates);
@@ -101,6 +103,7 @@ public class SchemaUtilsTest {
     verify(table).updateSchema();
     verify(updateSchema).addColumn(isNull(), matches("s"), isA(StringType.class));
     verify(updateSchema).updateColumn(matches("f"), isA(DoubleType.class));
+    verify(updateSchema).makeColumnOptional(matches("i"));
     verify(updateSchema).commit();
   }
 


### PR DESCRIPTION
This PR updates auto table create so the required/optional flag from the record schema is applied. Also, changing a required field to optional will be applied to the Iceberg schema.

The optional flag from the record schema is ignored when it is incompatible. For example, adding a column always adds it as optional. Updating a field from optional to required is ignored.