### PR TITLE
Place CDC metadata in struct/map in SMTs

### DIFF
--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
@@ -24,9 +24,10 @@ public interface CdcConstants {
   String OP_UPDATE = "U";
   String OP_DELETE = "D";
 
-  String COL_CDC_OP = "_cdc_op";
-  String COL_CDC_TS = "_cdc_ts";
-  String COL_CDC_TABLE = "_cdc_table";
-  String COL_CDC_TARGET = "_cdc_target";
-  String COL_CDC_KEY = "_cdc_key";
+  String COL_CDC = "_cdc";
+  String COL_OP = "op";
+  String COL_TS = "ts";
+  String COL_SOURCE = "source";
+  String COL_TARGET = "target";
+  String COL_KEY = "key";
 }

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
@@ -27,7 +27,9 @@ public interface CdcConstants {
   String COL_CDC = "_cdc";
   String COL_OP = "op";
   String COL_TS = "ts";
+  String COL_OFFSET = "offset";
   String COL_SOURCE = "source";
   String COL_TARGET = "target";
   String COL_KEY = "key";
+  String COL_TXN = "txn";
 }

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/CdcConstants.java
@@ -31,5 +31,4 @@ public interface CdcConstants {
   String COL_SOURCE = "source";
   String COL_TARGET = "target";
   String COL_KEY = "key";
-  String COL_TXN = "txn";
 }

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/DebeziumTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/DebeziumTransform.java
@@ -86,20 +86,25 @@ public class DebeziumTransform<R extends ConnectRecord<R>> implements Transforma
       payloadSchema = value.schema().field("after").schema();
     }
 
-    Schema newValueSchema = makeUpdatedSchema(payloadSchema, record.keySchema());
+    // create the CDC metadata
+    Schema cdcSchema = makeCdcSchema(record.keySchema());
+    Struct cdcMetadata = new Struct(cdcSchema);
+    cdcMetadata.put(CdcConstants.COL_OP, op);
+    cdcMetadata.put(CdcConstants.COL_TS, new java.util.Date(value.getInt64("ts_ms")));
+    setTableAndTargetFromSourceStruct(value.getStruct("source"), cdcMetadata);
+
+    if (record.keySchema() != null) {
+      cdcMetadata.put(CdcConstants.COL_KEY, record.key());
+    }
+
+    // create the new value
+    Schema newValueSchema = makeUpdatedSchema(payloadSchema, cdcSchema);
     Struct newValue = new Struct(newValueSchema);
 
     for (Field field : payloadSchema.fields()) {
       newValue.put(field.name(), payload.get(field));
     }
-
-    newValue.put(CdcConstants.COL_CDC_OP, op);
-    newValue.put(CdcConstants.COL_CDC_TS, new java.util.Date(value.getInt64("ts_ms")));
-    setTableAndTargetFromSourceStruct(value.getStruct("source"), newValue);
-
-    if (record.keySchema() != null) {
-      newValue.put(CdcConstants.COL_CDC_KEY, record.key());
-    }
+    newValue.put(CdcConstants.COL_CDC, cdcMetadata);
 
     return record.newRecord(
         record.topic(),
@@ -129,14 +134,19 @@ public class DebeziumTransform<R extends ConnectRecord<R>> implements Transforma
       return null;
     }
 
-    Map<String, Object> newValue = Maps.newHashMap((Map<String, Object>) payload);
-    newValue.put(CdcConstants.COL_CDC_OP, op);
-    newValue.put(CdcConstants.COL_CDC_TS, value.get("ts_ms"));
-    setTableAndTargetFromSourceMap(value.get("source"), newValue);
+    // create the CDC metadata
+    Map<String, Object> cdcMetadata = Maps.newHashMap();
+    cdcMetadata.put(CdcConstants.COL_OP, op);
+    cdcMetadata.put(CdcConstants.COL_TS, value.get("ts_ms"));
+    setTableAndTargetFromSourceMap(value.get("source"), cdcMetadata);
 
     if (record.key() instanceof Map) {
-      newValue.put(CdcConstants.COL_CDC_KEY, record.key());
+      cdcMetadata.put(CdcConstants.COL_KEY, record.key());
     }
+
+    // create the new value
+    Map<String, Object> newValue = Maps.newHashMap((Map<String, Object>) payload);
+    newValue.put(CdcConstants.COL_CDC, cdcMetadata);
 
     return record.newRecord(
         record.topic(),
@@ -160,7 +170,7 @@ public class DebeziumTransform<R extends ConnectRecord<R>> implements Transforma
     }
   }
 
-  private void setTableAndTargetFromSourceStruct(Struct source, Struct value) {
+  private void setTableAndTargetFromSourceStruct(Struct source, Struct cdcMetadata) {
     String db;
     if (source.schema().field("schema") != null) {
       // prefer schema if present, e.g. for Postgres
@@ -170,11 +180,11 @@ public class DebeziumTransform<R extends ConnectRecord<R>> implements Transforma
     }
     String table = source.getString("table");
 
-    value.put(CdcConstants.COL_CDC_TABLE, db + "." + table);
-    value.put(CdcConstants.COL_CDC_TARGET, target(db, table));
+    cdcMetadata.put(CdcConstants.COL_SOURCE, db + "." + table);
+    cdcMetadata.put(CdcConstants.COL_TARGET, target(db, table));
   }
 
-  private void setTableAndTargetFromSourceMap(Object source, Map<String, Object> value) {
+  private void setTableAndTargetFromSourceMap(Object source, Map<String, Object> cdcMetadata) {
     Map<String, Object> map = Requirements.requireMap(source, "Debezium transform");
 
     String db;
@@ -186,8 +196,8 @@ public class DebeziumTransform<R extends ConnectRecord<R>> implements Transforma
     }
     String table = map.get("table").toString();
 
-    value.put(CdcConstants.COL_CDC_TABLE, db + "." + table);
-    value.put(CdcConstants.COL_CDC_TARGET, target(db, table));
+    cdcMetadata.put(CdcConstants.COL_SOURCE, db + "." + table);
+    cdcMetadata.put(CdcConstants.COL_TARGET, target(db, table));
   }
 
   private String target(String db, String table) {
@@ -196,22 +206,29 @@ public class DebeziumTransform<R extends ConnectRecord<R>> implements Transforma
         : cdcTargetPattern.replace(DB_PLACEHOLDER, db).replace(TABLE_PLACEHOLDER, table);
   }
 
-  private Schema makeUpdatedSchema(Schema schema, Schema keySchema) {
+  private Schema makeCdcSchema(Schema keySchema) {
+    SchemaBuilder builder =
+        SchemaBuilder.struct()
+            .field(CdcConstants.COL_OP, Schema.STRING_SCHEMA)
+            .field(CdcConstants.COL_TS, Timestamp.SCHEMA)
+            .field(CdcConstants.COL_SOURCE, Schema.STRING_SCHEMA)
+            .field(CdcConstants.COL_TARGET, Schema.STRING_SCHEMA);
+
+    if (keySchema != null) {
+      builder.field(CdcConstants.COL_KEY, keySchema);
+    }
+
+    return builder.build();
+  }
+
+  private Schema makeUpdatedSchema(Schema schema, Schema cdcSchema) {
     SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
 
     for (Field field : schema.fields()) {
       builder.field(field.name(), field.schema());
     }
 
-    builder
-        .field(CdcConstants.COL_CDC_OP, Schema.STRING_SCHEMA)
-        .field(CdcConstants.COL_CDC_TS, Timestamp.SCHEMA)
-        .field(CdcConstants.COL_CDC_TABLE, Schema.STRING_SCHEMA)
-        .field(CdcConstants.COL_CDC_TARGET, Schema.STRING_SCHEMA);
-
-    if (keySchema != null) {
-      builder.field(CdcConstants.COL_CDC_KEY, keySchema);
-    }
+    builder.field(CdcConstants.COL_CDC, cdcSchema);
 
     return builder.build();
   }

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DebeziumTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DebeziumTransformTest.java
@@ -84,10 +84,12 @@ public class DebeziumTransformTest {
       Map<String, Object> value = (Map<String, Object>) result.value();
 
       assertThat(value.get("account_id")).isEqualTo(1);
-      assertThat(value.get("_cdc_table")).isEqualTo("schema.tbl");
-      assertThat(value.get("_cdc_target")).isEqualTo("schema_x.tbl_x");
-      assertThat(value.get("_cdc_op")).isEqualTo("U");
-      assertThat(value.get("_cdc_key")).isInstanceOf(Map.class);
+
+      Map<String, Object> cdcMetadata = (Map<String, Object>) value.get("_cdc");
+      assertThat(cdcMetadata.get("op")).isEqualTo("U");
+      assertThat(cdcMetadata.get("source")).isEqualTo("schema.tbl");
+      assertThat(cdcMetadata.get("target")).isEqualTo("schema_x.tbl_x");
+      assertThat(cdcMetadata.get("key")).isInstanceOf(Map.class);
     }
   }
 
@@ -105,10 +107,12 @@ public class DebeziumTransformTest {
       Struct value = (Struct) result.value();
 
       assertThat(value.get("account_id")).isEqualTo(1L);
-      assertThat(value.get("_cdc_table")).isEqualTo("schema.tbl");
-      assertThat(value.get("_cdc_target")).isEqualTo("schema_x.tbl_x");
-      assertThat(value.get("_cdc_op")).isEqualTo("U");
-      assertThat(value.get("_cdc_key")).isInstanceOf(Struct.class);
+
+      Struct cdcMetadata = value.getStruct("_cdc");
+      assertThat(cdcMetadata.get("op")).isEqualTo("U");
+      assertThat(cdcMetadata.get("source")).isEqualTo("schema.tbl");
+      assertThat(cdcMetadata.get("target")).isEqualTo("schema_x.tbl_x");
+      assertThat(cdcMetadata.get("key")).isInstanceOf(Struct.class);
     }
   }
 

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DebeziumTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DebeziumTransformTest.java
@@ -50,20 +50,11 @@ public class DebeziumTransformTest {
           .field("table", Schema.STRING_SCHEMA)
           .build();
 
-  private static final Schema TXN_SCHEMA =
-      SchemaBuilder.struct()
-          .optional()
-          .field("id", Schema.STRING_SCHEMA)
-          .field("total_order", Schema.INT64_SCHEMA)
-          .field("data_collection_order", Schema.INT64_SCHEMA)
-          .build();
-
   private static final Schema VALUE_SCHEMA =
       SchemaBuilder.struct()
           .field("op", Schema.STRING_SCHEMA)
           .field("ts_ms", Schema.INT64_SCHEMA)
           .field("source", SOURCE_SCHEMA)
-          .field("transaction", TXN_SCHEMA)
           .field("before", ROW_SCHEMA)
           .field("after", ROW_SCHEMA)
           .build();
@@ -98,7 +89,6 @@ public class DebeziumTransformTest {
       assertThat(cdcMetadata.get("source")).isEqualTo("schema.tbl");
       assertThat(cdcMetadata.get("target")).isEqualTo("schema_x.tbl_x");
       assertThat(cdcMetadata.get("key")).isInstanceOf(Map.class);
-      assertThat(cdcMetadata.get("txn")).isInstanceOf(Map.class);
     }
   }
 
@@ -122,7 +112,6 @@ public class DebeziumTransformTest {
       assertThat(cdcMetadata.get("source")).isEqualTo("schema.tbl");
       assertThat(cdcMetadata.get("target")).isEqualTo("schema_x.tbl_x");
       assertThat(cdcMetadata.get("key")).isInstanceOf(Struct.class);
-      assertThat(cdcMetadata.get("txn")).isInstanceOf(Struct.class);
     }
   }
 
@@ -131,14 +120,7 @@ public class DebeziumTransformTest {
         ImmutableMap.of(
             "db", "db",
             "schema", "schema",
-            "table", "tbl",
-            "txId", 12345);
-
-    Map<String, Object> txn =
-        ImmutableMap.of(
-            "id", "123:123",
-            "total_order", 1L,
-            "data_collection_order", 1L);
+            "table", "tbl");
 
     Map<String, Object> data =
         ImmutableMap.of(
@@ -150,7 +132,6 @@ public class DebeziumTransformTest {
         "op", operation,
         "ts_ms", System.currentTimeMillis(),
         "source", source,
-        "transaction", txn,
         "before", data,
         "after", data);
   }
@@ -158,12 +139,6 @@ public class DebeziumTransformTest {
   private Struct createDebeziumEventStruct(String operation) {
     Struct source =
         new Struct(SOURCE_SCHEMA).put("db", "db").put("schema", "schema").put("table", "tbl");
-
-    Struct txn =
-        new Struct(TXN_SCHEMA)
-            .put("id", "123:123")
-            .put("total_order", 1L)
-            .put("data_collection_order", 1L);
 
     Struct data =
         new Struct(ROW_SCHEMA)
@@ -175,7 +150,6 @@ public class DebeziumTransformTest {
         .put("op", operation)
         .put("ts_ms", System.currentTimeMillis())
         .put("source", source)
-        .put("transaction", txn)
         .put("before", data)
         .put("after", data);
   }

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DmsTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/DmsTransformTest.java
@@ -40,8 +40,10 @@ public class DmsTransformTest {
       Map<String, Object> value = (Map<String, Object>) result.value();
 
       assertThat(value.get("account_id")).isEqualTo(1);
-      assertThat(value.get("_cdc_table")).isEqualTo("db.tbl");
-      assertThat(value.get("_cdc_op")).isEqualTo("U");
+
+      Map<String, Object> cdcMetadata = (Map<String, Object>) value.get("_cdc");
+      assertThat(cdcMetadata.get("op")).isEqualTo("U");
+      assertThat(cdcMetadata.get("source")).isEqualTo("db.tbl");
     }
   }
 


### PR DESCRIPTION
This PR updates the CDC schema to put metadata in a struct/map field named `_cdc`, in the DMS and Debezium SMTs. For Debezium, the stucture of the record will look something like:
```json
{
	"id": 123
	"col1": "abc",
	"col2": "xyz",
	"_cdc": {
	  "op": "U",
	  "ts": 12312312313,
	  "source": "public.accounts",
	  "target": "db.accounts_cdc",
          "offset": 123,
	  "key": {
	    "id": 123
	  }
	}
}
```
