### PR TITLE
Add config for setting properties for writers and table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.auto-create-enabled         | Set to `true` to automatically create destination tables, default is `false`                                  |
 | iceberg.tables.evolve-schema-enabled       | Set to `true` to add any missing record fields to the table schema, default is `false`                        |
 | iceberg.tables.auto-create-props.*         | Properties set on new tables during auto-create                                                               |
-| iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization                                                    |
+| iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization, these take precedence                             |
 | iceberg.table.\<table name\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                |
 | iceberg.table.\<table name\>.id-columns    | Comma-separated list of columns that identify a row in the table (primary key)                                |
 | iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                       |

--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.upsert-mode-enabled         | Set to `true` to enable upsert mode, default is `false`                                                       |
 | iceberg.tables.auto-create-enabled         | Set to `true` to automatically create destination tables, default is `false`                                  |
 | iceberg.tables.evolve-schema-enabled       | Set to `true` to add any missing record fields to the table schema, default is `false`                        |
+| iceberg.tables.auto-create-props.*         | Properties set on new tables during auto-create                                                               |
+| iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization                                                    |
+| iceberg.table.\<table name\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                |
 | iceberg.table.\<table name\>.id-columns    | Comma-separated list of columns that identify a row in the table (primary key)                                |
 | iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                       |
 | iceberg.table.\<table name\>.route-regex   | The regex used to match a record's `routeField` to a table                                                    |
-| iceberg.table.\<table name\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                |
 | iceberg.control.topic                      | Name of the control topic, default is `control-iceberg`                                                       |
 | iceberg.control.group-id                   | Name of the consumer group to store offsets, default is `cg-control-<connector name>`                         |
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                           |

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -7,7 +7,7 @@ dependencies {
   compileOnly libs.bundles.kafka.connect
 
   testImplementation(testFixtures(project(":iceberg-kafka-connect-events")))
-  testImplementation libs.hadoop.common
+  testImplementation libs.hadoop.client
 
   testImplementation libs.junit.api
   testImplementation libs.junit.params

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -61,6 +61,8 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String HADOOP_PROP_PREFIX = "iceberg.hadoop.";
   private static final String KAFKA_PROP_PREFIX = "iceberg.kafka.";
   private static final String TABLE_PROP_PREFIX = "iceberg.table.";
+  private static final String AUTO_CREATE_PROP_PREFIX = "iceberg.tables.auto-create-props.";
+  private static final String WRITE_PROP_PREFIX = "iceberg.table.write-props.";
 
   private static final String CATALOG_NAME_PROP = "iceberg.catalog";
   private static final String TABLES_PROP = "iceberg.tables";
@@ -223,6 +225,8 @@ public class IcebergSinkConfig extends AbstractConfig {
   private final Map<String, String> catalogProps;
   private final Map<String, String> hadoopProps;
   private final Map<String, String> kafkaProps;
+  private final Map<String, String> autoCreateProps;
+  private final Map<String, String> writeProps;
   private final Map<String, TableSinkConfig> tableConfigMap = Maps.newHashMap();
   private final JsonConverter jsonConverter;
 
@@ -235,6 +239,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
     this.kafkaProps = Maps.newHashMap(loadWorkerProps());
     kafkaProps.putAll(PropertyUtil.propertiesWithPrefix(originalProps, KAFKA_PROP_PREFIX));
+
+    this.autoCreateProps =
+        PropertyUtil.propertiesWithPrefix(originalProps, AUTO_CREATE_PROP_PREFIX);
+    this.writeProps = PropertyUtil.propertiesWithPrefix(originalProps, WRITE_PROP_PREFIX);
 
     this.jsonConverter = new JsonConverter();
     jsonConverter.configure(
@@ -284,6 +292,14 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public Map<String, String> kafkaProps() {
     return kafkaProps;
+  }
+
+  public Map<String, String> autoCreateProps() {
+    return autoCreateProps;
+  }
+
+  public Map<String, String> writeProps() {
+    return writeProps;
   }
 
   public String catalogName() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriterFactory.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.Tasks;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -63,7 +64,8 @@ public class IcebergWriterFactory {
     return new IcebergWriter(table, tableName, config);
   }
 
-  private Table autoCreateTable(String tableName, SinkRecord sample) {
+  @VisibleForTesting
+  Table autoCreateTable(String tableName, SinkRecord sample) {
     StructType structType;
     if (sample.valueSchema() == null) {
       structType = SchemaUtils.inferIcebergType(sample.value()).asStructType();

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriterFactory.java
@@ -96,7 +96,9 @@ public class IcebergWriterFactory {
               try {
                 result.set(catalog.loadTable(identifier));
               } catch (NoSuchTableException e) {
-                result.set(catalog.createTable(identifier, schema, partitionSpec));
+                result.set(
+                    catalog.createTable(
+                        identifier, schema, partitionSpec, config.autoCreateProps()));
               }
             });
     return result.get();

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/IcebergWriterFactoryTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/IcebergWriterFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.tabular.iceberg.connect.IcebergSinkConfig;
+import io.tabular.iceberg.connect.TableSinkConfig;
+import java.util.Map;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types.LongType;
+import org.apache.iceberg.types.Types.StringType;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+public class IcebergWriterFactoryTest {
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @SuppressWarnings("unchecked")
+  public void testAutoCreateTable(boolean partitioned) {
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    TableSinkConfig tableConfig = mock(TableSinkConfig.class);
+    if (partitioned) {
+      when(tableConfig.partitionBy()).thenReturn(ImmutableList.of("data"));
+    }
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateProps()).thenReturn(ImmutableMap.of("test-prop", "foo1"));
+    when(config.tableConfig(any())).thenReturn(tableConfig);
+
+    SinkRecord record = mock(SinkRecord.class);
+    when(record.value()).thenReturn(ImmutableMap.of("id", 123, "data", "foo2"));
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+    factory.autoCreateTable("db.tbl", record);
+
+    ArgumentCaptor<TableIdentifier> identCaptor = ArgumentCaptor.forClass(TableIdentifier.class);
+    ArgumentCaptor<Schema> schemaCaptor = ArgumentCaptor.forClass(Schema.class);
+    ArgumentCaptor<PartitionSpec> specCaptor = ArgumentCaptor.forClass(PartitionSpec.class);
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass(Map.class);
+
+    verify(catalog)
+        .createTable(
+            identCaptor.capture(),
+            schemaCaptor.capture(),
+            specCaptor.capture(),
+            propsCaptor.capture());
+
+    assertThat(identCaptor.getValue()).isEqualTo(TableIdentifier.of("db", "tbl"));
+    assertThat(schemaCaptor.getValue().findField("id").type()).isEqualTo(LongType.get());
+    assertThat(schemaCaptor.getValue().findField("data").type()).isEqualTo(StringType.get());
+    assertThat(specCaptor.getValue().isPartitioned()).isEqualTo(partitioned);
+    assertThat(propsCaptor.getValue()).containsKey("test-prop");
+  }
+}

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/PartitionedAppendWriterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/PartitionedAppendWriterTest.java
@@ -25,18 +25,23 @@ import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.TableSinkConfig;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.Test;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class PartitionedAppendWriterTest extends BaseWriterTest {
 
-  @Test
-  public void testPartitionedAppendWriter() {
+  @ParameterizedTest
+  @ValueSource(strings = {"parquet", "orc"})
+  public void testPartitionedAppendWriter(String format) {
     IcebergSinkConfig config = mock(IcebergSinkConfig.class);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.writeProps()).thenReturn(ImmutableMap.of("write.format.default", format));
 
     when(table.spec()).thenReturn(SPEC);
 
@@ -55,6 +60,7 @@ public class PartitionedAppendWriterTest extends BaseWriterTest {
 
     // 1 data file for each partition (2 total)
     assertThat(result.dataFiles()).hasSize(2);
+    assertThat(result.dataFiles()).allMatch(file -> file.format() == FileFormat.fromString(format));
     assertThat(result.deleteFiles()).hasSize(0);
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriterTest.java
@@ -25,19 +25,24 @@ import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.TableSinkConfig;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.Test;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class PartitionedDeltaWriterTest extends BaseWriterTest {
 
-  @Test
-  public void testPartitionedDeltaWriter() {
+  @ParameterizedTest
+  @ValueSource(strings = {"parquet", "orc"})
+  public void testPartitionedDeltaWriter(String format) {
     IcebergSinkConfig config = mock(IcebergSinkConfig.class);
     when(config.upsertModeEnabled()).thenReturn(true);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.writeProps()).thenReturn(ImmutableMap.of("write.format.default", format));
 
     when(table.spec()).thenReturn(SPEC);
 
@@ -57,6 +62,9 @@ public class PartitionedDeltaWriterTest extends BaseWriterTest {
     // in upsert mode, each write is a delete + append, so we'll have 1 data file
     // and 1 delete file for each partition (2 total)
     assertThat(result.dataFiles()).hasSize(2);
+    assertThat(result.dataFiles()).allMatch(file -> file.format() == FileFormat.fromString(format));
     assertThat(result.deleteFiles()).hasSize(2);
+    assertThat(result.deleteFiles())
+        .allMatch(file -> file.format() == FileFormat.fromString(format));
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UnpartitionedWriterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UnpartitionedWriterTest.java
@@ -25,19 +25,24 @@ import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.TableSinkConfig;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.UnpartitionedWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.Test;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class UnpartitionedWriterTest extends BaseWriterTest {
 
-  @Test
-  public void testUnpartitionedWriter() {
+  @ParameterizedTest
+  @ValueSource(strings = {"parquet", "orc"})
+  public void testUnpartitionedWriter(String format) {
     IcebergSinkConfig config = mock(IcebergSinkConfig.class);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.writeProps()).thenReturn(ImmutableMap.of("write.format.default", format));
 
     Record row1 = GenericRecord.create(SCHEMA);
     row1.setField("id", 123L);
@@ -52,6 +57,7 @@ public class UnpartitionedWriterTest extends BaseWriterTest {
     WriteResult result = writeTest(ImmutableList.of(row1, row2), config, UnpartitionedWriter.class);
 
     assertThat(result.dataFiles()).hasSize(1);
+    assertThat(result.dataFiles()).allMatch(file -> file.format() == FileFormat.fromString(format));
     assertThat(result.deleteFiles()).hasSize(0);
   }
 }


### PR DESCRIPTION
This PR adds some config options that allow setting Iceberg table properties for auto-create, and Iceberg writer properties.