### PR TITLE
Fix delta writer when relying on ID col config

### DIFF
--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestEvent.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestEvent.java
@@ -48,6 +48,14 @@ public class TestEvent {
               Types.NestedField.required(4, "payload", Types.StringType.get())),
           ImmutableSet.of(1));
 
+  public static final Schema TEST_SCHEMA_NO_ID =
+      new Schema(
+          ImmutableList.of(
+              Types.NestedField.required(1, "id", Types.LongType.get()),
+              Types.NestedField.required(2, "type", Types.StringType.get()),
+              Types.NestedField.required(3, "ts", Types.TimestampType.withZone()),
+              Types.NestedField.required(4, "payload", Types.StringType.get())));
+
   public static final org.apache.kafka.connect.data.Schema TEST_CONNECT_SCHEMA =
       SchemaBuilder.struct()
           .field("id", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/BaseDeltaTaskWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/BaseDeltaTaskWriter.java
@@ -51,11 +51,11 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
       FileIO io,
       long targetFileSize,
       Schema schema,
-      Set<Integer> equalityFieldIds,
+      Set<Integer> identifierFieldIds,
       boolean upsertMode) {
     super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
     this.schema = schema;
-    this.deleteSchema = TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds));
+    this.deleteSchema = TypeUtil.select(schema, Sets.newHashSet(identifierFieldIds));
     this.wrapper = new InternalRecordWrapper(schema.asStruct());
     this.keyWrapper = new InternalRecordWrapper(deleteSchema.asStruct());
     this.keyProjection = RecordProjection.create(schema, deleteSchema);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/BaseDeltaTaskWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/BaseDeltaTaskWriter.java
@@ -19,6 +19,7 @@
 package io.tabular.iceberg.connect.data;
 
 import java.io.IOException;
+import java.util.Set;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
@@ -50,10 +51,11 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
       FileIO io,
       long targetFileSize,
       Schema schema,
+      Set<Integer> equalityFieldIds,
       boolean upsertMode) {
     super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
     this.schema = schema;
-    this.deleteSchema = TypeUtil.select(schema, Sets.newHashSet(schema.identifierFieldIds()));
+    this.deleteSchema = TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds));
     this.wrapper = new InternalRecordWrapper(schema.asStruct());
     this.keyWrapper = new InternalRecordWrapper(deleteSchema.asStruct());
     this.keyProjection = RecordProjection.create(schema, deleteSchema);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriter.java
@@ -21,6 +21,7 @@ package io.tabular.iceberg.connect.data;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
@@ -45,8 +46,18 @@ public class PartitionedDeltaWriter extends BaseDeltaTaskWriter {
       FileIO io,
       long targetFileSize,
       Schema schema,
+      Set<Integer> equalityFieldIds,
       boolean upsertMode) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, upsertMode);
+    super(
+        spec,
+        format,
+        appenderFactory,
+        fileFactory,
+        io,
+        targetFileSize,
+        schema,
+        equalityFieldIds,
+        upsertMode);
     this.partitionKey = new PartitionKey(spec, schema);
   }
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriter.java
@@ -46,7 +46,7 @@ public class PartitionedDeltaWriter extends BaseDeltaTaskWriter {
       FileIO io,
       long targetFileSize,
       Schema schema,
-      Set<Integer> equalityFieldIds,
+      Set<Integer> identifierFieldIds,
       boolean upsertMode) {
     super(
         spec,
@@ -56,7 +56,7 @@ public class PartitionedDeltaWriter extends BaseDeltaTaskWriter {
         io,
         targetFileSize,
         schema,
-        equalityFieldIds,
+        identifierFieldIds,
         upsertMode);
     this.partitionKey = new PartitionKey(spec, schema);
   }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/UnpartitionedDeltaWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/UnpartitionedDeltaWriter.java
@@ -39,7 +39,7 @@ public class UnpartitionedDeltaWriter extends BaseDeltaTaskWriter {
       FileIO io,
       long targetFileSize,
       Schema schema,
-      Set<Integer> equalityFieldIds,
+      Set<Integer> identifierFieldIds,
       boolean upsertMode) {
     super(
         spec,
@@ -49,7 +49,7 @@ public class UnpartitionedDeltaWriter extends BaseDeltaTaskWriter {
         io,
         targetFileSize,
         schema,
-        equalityFieldIds,
+        identifierFieldIds,
         upsertMode);
     this.writer = new RowDataDeltaWriter(null);
   }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/UnpartitionedDeltaWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/UnpartitionedDeltaWriter.java
@@ -19,6 +19,7 @@
 package io.tabular.iceberg.connect.data;
 
 import java.io.IOException;
+import java.util.Set;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -38,8 +39,18 @@ public class UnpartitionedDeltaWriter extends BaseDeltaTaskWriter {
       FileIO io,
       long targetFileSize,
       Schema schema,
+      Set<Integer> equalityFieldIds,
       boolean upsertMode) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, upsertMode);
+    super(
+        spec,
+        format,
+        appenderFactory,
+        fileFactory,
+        io,
+        targetFileSize,
+        schema,
+        equalityFieldIds,
+        upsertMode);
     this.writer = new RowDataDeltaWriter(null);
   }
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
@@ -168,19 +168,19 @@ public class Utilities {
         PropertyUtil.propertyAsLong(
             tableProps, WRITE_TARGET_FILE_SIZE_BYTES, WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
 
-    Set<Integer> equalityFieldIds = table.schema().identifierFieldIds();
+    Set<Integer> identifierFieldIds = table.schema().identifierFieldIds();
 
     // override the identifier fields if the config is set
     List<String> idCols = config.tableConfig(tableName).idColumns();
     if (!idCols.isEmpty()) {
-      equalityFieldIds =
+      identifierFieldIds =
           idCols.stream()
               .map(colName -> table.schema().findField(colName).fieldId())
               .collect(toSet());
     }
 
     FileAppenderFactory<Record> appenderFactory;
-    if (equalityFieldIds == null || equalityFieldIds.isEmpty()) {
+    if (identifierFieldIds == null || identifierFieldIds.isEmpty()) {
       appenderFactory =
           new GenericAppenderFactory(table.schema(), table.spec(), null, null, null)
               .setAll(tableProps);
@@ -189,8 +189,8 @@ public class Utilities {
           new GenericAppenderFactory(
                   table.schema(),
                   table.spec(),
-                  Ints.toArray(equalityFieldIds),
-                  TypeUtil.select(table.schema(), Sets.newHashSet(equalityFieldIds)),
+                  Ints.toArray(identifierFieldIds),
+                  TypeUtil.select(table.schema(), Sets.newHashSet(identifierFieldIds)),
                   null)
               .setAll(tableProps);
     }
@@ -219,7 +219,7 @@ public class Utilities {
                 table.io(),
                 targetFileSize,
                 table.schema(),
-                equalityFieldIds,
+                identifierFieldIds,
                 config.upsertModeEnabled());
       }
     } else {
@@ -243,7 +243,7 @@ public class Utilities {
                 table.io(),
                 targetFileSize,
                 table.schema(),
-                equalityFieldIds,
+                identifierFieldIds,
                 config.upsertModeEnabled());
       }
     }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
@@ -219,6 +219,7 @@ public class Utilities {
                 table.io(),
                 targetFileSize,
                 table.schema(),
+                equalityFieldIds,
                 config.upsertModeEnabled());
       }
     } else {
@@ -242,6 +243,7 @@ public class Utilities {
                 table.io(),
                 targetFileSize,
                 table.schema(),
+                equalityFieldIds,
                 config.upsertModeEnabled());
       }
     }


### PR DESCRIPTION
This PR updates the writer initialization to pass down the equality ID fields defined in the config if present, rather than relying on the schema's identifier columns.