### PR TITLE
Add config to force optional cols on auto create and schema evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,35 +20,35 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 
 # Configuration
 
-| Property                                   | Description                                                                                                   |
-|--------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| iceberg.tables                             | Comma-separated list of destination tables                                                                    |
-| iceberg.tables.dynamic-enabled             | Set to `true` to route to a table specified in `routeField` instead of using `routeRegex`, default is `false` |
-| iceberg.tables.route-field                 | For multi-table fan-out, the name of the field used to route records to tables                                |
-| iceberg.tables.default-commit-branch       | Default branch for commits, main is used if not specified                                                     |
-| iceberg.tables.default-id-columns          | Default comma-separated list of columns that identify a row in tables (primary key)                           |
-| iceberg.tables.default-partition-by        | Default comma-separated list of partition fields to use when creating tables                                  |
-| iceberg.tables.cdc-field                   | Name of the field containing the CDC operation, `I`, `U`, or `D`, default is none                             |
-| iceberg.tables.upsert-mode-enabled         | Set to `true` to enable upsert mode, default is `false`                                                       |
-| iceberg.tables.auto-create-enabled         | Set to `true` to automatically create destination tables, default is `false`                                  |
-| iceberg.tables.auto-create-force-optional  | Set to `true` to set all columns to optional during auto create, default is `false` to respect schema         |
-| iceberg.tables.evolve-schema-enabled       | Set to `true` to add any missing record fields to the table schema, default is `false`                        |
-| iceberg.tables.auto-create-props.*         | Properties set on new tables during auto-create                                                               |
-| iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization, these take precedence                             |
-| iceberg.table.\<table name\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                |
-| iceberg.table.\<table name\>.id-columns    | Comma-separated list of columns that identify a row in the table (primary key)                                |
-| iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                       |
-| iceberg.table.\<table name\>.route-regex   | The regex used to match a record's `routeField` to a table                                                    |
-| iceberg.control.topic                      | Name of the control topic, default is `control-iceberg`                                                       |
-| iceberg.control.group-id                   | Name of the consumer group to store offsets, default is `cg-control-<connector name>`                         |
-| iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                           |
-| iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                   |
-| iceberg.control.commit.threads             | Number of threads to use for commits, default is (cores * 2)                                                  |
-| iceberg.catalog                            | Name of the catalog, default is `iceberg`                                                                     |
-| iceberg.catalog.*                          | Properties passed through to Iceberg catalog initialization                                                   |
-| iceberg.hadoop-conf-dir                    | If specified, Hadoop config files in this directory will be loaded                                            |
-| iceberg.hadoop.*                           | Properties passed through to the Hadoop configuration                                                         |
-| iceberg.kafka.*                            | Properties passed through to control topic Kafka client initialization                                        |
+| Property                                   | Description                                                                                                      |
+|--------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| iceberg.tables                             | Comma-separated list of destination tables                                                                       |
+| iceberg.tables.dynamic-enabled             | Set to `true` to route to a table specified in `routeField` instead of using `routeRegex`, default is `false`    |
+| iceberg.tables.route-field                 | For multi-table fan-out, the name of the field used to route records to tables                                   |
+| iceberg.tables.default-commit-branch       | Default branch for commits, main is used if not specified                                                        |
+| iceberg.tables.default-id-columns          | Default comma-separated list of columns that identify a row in tables (primary key)                              |
+| iceberg.tables.default-partition-by        | Default comma-separated list of partition fields to use when creating tables                                     |
+| iceberg.tables.cdc-field                   | Name of the field containing the CDC operation, `I`, `U`, or `D`, default is none                                |
+| iceberg.tables.upsert-mode-enabled         | Set to `true` to enable upsert mode, default is `false`                                                          |
+| iceberg.tables.auto-create-enabled         | Set to `true` to automatically create destination tables, default is `false`                                     |
+| iceberg.tables.evolve-schema-enabled       | Set to `true` to add any missing record fields to the table schema, default is `false`                           |
+| iceberg.tables.schema-force-optional       | Set to `true` to set columns as optional during table create and evolution, default is `false` to respect schema |
+| iceberg.tables.auto-create-props.*         | Properties set on new tables during auto-create                                                                  |
+| iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization, these take precedence                                |
+| iceberg.table.\<table name\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                   |
+| iceberg.table.\<table name\>.id-columns    | Comma-separated list of columns that identify a row in the table (primary key)                                   |
+| iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                          |
+| iceberg.table.\<table name\>.route-regex   | The regex used to match a record's `routeField` to a table                                                       |
+| iceberg.control.topic                      | Name of the control topic, default is `control-iceberg`                                                          |
+| iceberg.control.group-id                   | Name of the consumer group to store offsets, default is `cg-control-<connector name>`                            |
+| iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
+| iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
+| iceberg.control.commit.threads             | Number of threads to use for commits, default is (cores * 2)                                                     |
+| iceberg.catalog                            | Name of the catalog, default is `iceberg`                                                                        |
+| iceberg.catalog.*                          | Properties passed through to Iceberg catalog initialization                                                      |
+| iceberg.hadoop-conf-dir                    | If specified, Hadoop config files in this directory will be loaded                                               |
+| iceberg.hadoop.*                           | Properties passed through to the Hadoop configuration                                                            |
+| iceberg.kafka.*                            | Properties passed through to control topic Kafka client initialization                                           |
 
 If `iceberg.tables.dynamic-enabled` is `false` (the default) then you must specify `iceberg.tables`. If
 `iceberg.tables.dynamic-enabled` is `true` then you must specify `iceberg.tables.route-field` which will

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.cdc-field                   | Name of the field containing the CDC operation, `I`, `U`, or `D`, default is none                             |
 | iceberg.tables.upsert-mode-enabled         | Set to `true` to enable upsert mode, default is `false`                                                       |
 | iceberg.tables.auto-create-enabled         | Set to `true` to automatically create destination tables, default is `false`                                  |
+| iceberg.tables.auto-create-force-optional  | Set to `true` to set all columns to optional during auto create, default is `false` to respect schema         |
 | iceberg.tables.evolve-schema-enabled       | Set to `true` to add any missing record fields to the table schema, default is `false`                        |
 | iceberg.tables.auto-create-props.*         | Properties set on new tables during auto-create                                                               |
 | iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization, these take precedence                             |

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -76,6 +76,8 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.upsert-mode-enabled";
   private static final String TABLES_AUTO_CREATE_ENABLED_PROP =
       "iceberg.tables.auto-create-enabled";
+  private static final String TABLES_AUTO_CREATE_FORCE_OPTIONAL_PROP =
+      "iceberg.tables.auto-create-force-optional";
   private static final String TABLES_EVOLVE_SCHEMA_ENABLED_PROP =
       "iceberg.tables.evolve-schema-enabled";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
@@ -164,6 +166,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         false,
         Importance.MEDIUM,
         "Set to true to automatically create destination tables, false otherwise");
+    configDef.define(
+        TABLES_AUTO_CREATE_FORCE_OPTIONAL_PROP,
+        Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        "Set to true to set all columns to optional during auto create, false to respect schema");
     configDef.define(
         TABLES_EVOLVE_SCHEMA_ENABLED_PROP,
         Type.BOOLEAN,
@@ -413,6 +421,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public boolean autoCreateEnabled() {
     return getBoolean(TABLES_AUTO_CREATE_ENABLED_PROP);
+  }
+
+  public boolean autoCreateForceOptional() {
+    return getBoolean(TABLES_AUTO_CREATE_FORCE_OPTIONAL_PROP);
   }
 
   public boolean evolveSchemaEnabled() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -76,8 +76,8 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.upsert-mode-enabled";
   private static final String TABLES_AUTO_CREATE_ENABLED_PROP =
       "iceberg.tables.auto-create-enabled";
-  private static final String TABLES_AUTO_CREATE_FORCE_OPTIONAL_PROP =
-      "iceberg.tables.auto-create-force-optional";
+  private static final String TABLES_SCHEMA_FORCE_OPTIONAL_PROP =
+      "iceberg.tables.schema-force-optional";
   private static final String TABLES_EVOLVE_SCHEMA_ENABLED_PROP =
       "iceberg.tables.evolve-schema-enabled";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
@@ -167,11 +167,11 @@ public class IcebergSinkConfig extends AbstractConfig {
         Importance.MEDIUM,
         "Set to true to automatically create destination tables, false otherwise");
     configDef.define(
-        TABLES_AUTO_CREATE_FORCE_OPTIONAL_PROP,
+        TABLES_SCHEMA_FORCE_OPTIONAL_PROP,
         Type.BOOLEAN,
         false,
         Importance.MEDIUM,
-        "Set to true to set all columns to optional during auto create, false to respect schema");
+        "Set to true to set columns as optional during table create and evolution, false to respect schema");
     configDef.define(
         TABLES_EVOLVE_SCHEMA_ENABLED_PROP,
         Type.BOOLEAN,
@@ -423,8 +423,8 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getBoolean(TABLES_AUTO_CREATE_ENABLED_PROP);
   }
 
-  public boolean autoCreateForceOptional() {
-    return getBoolean(TABLES_AUTO_CREATE_FORCE_OPTIONAL_PROP);
+  public boolean schemaForceOptional() {
+    return getBoolean(TABLES_SCHEMA_FORCE_OPTIONAL_PROP);
   }
 
   public boolean evolveSchemaEnabled() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -51,7 +51,7 @@ public class IcebergWriter implements RecordWriter {
 
   private void initNewWriter() {
     this.writer = Utilities.createTableWriter(table, tableName, config);
-    this.recordConverter = new RecordConverter(table, config.jsonConverter());
+    this.recordConverter = new RecordConverter(table, config);
   }
 
   @Override

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriterFactory.java
@@ -68,9 +68,9 @@ public class IcebergWriterFactory {
   Table autoCreateTable(String tableName, SinkRecord sample) {
     StructType structType;
     if (sample.valueSchema() == null) {
-      structType = SchemaUtils.inferIcebergType(sample.value()).asStructType();
+      structType = SchemaUtils.inferIcebergType(sample.value(), config).asStructType();
     } else {
-      structType = SchemaUtils.toIcebergType(sample.valueSchema()).asStructType();
+      structType = SchemaUtils.toIcebergType(sample.valueSchema(), config).asStructType();
     }
 
     org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(structType.fields());

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
@@ -261,7 +261,7 @@ public class SchemaUtils {
           return DoubleType.get();
         case ARRAY:
           Type elementType = toIcebergType(valueSchema.valueSchema());
-          if (config.autoCreateForceOptional() || valueSchema.valueSchema().isOptional()) {
+          if (config.schemaForceOptional() || valueSchema.valueSchema().isOptional()) {
             return ListType.ofOptional(nextId(), elementType);
           } else {
             return ListType.ofRequired(nextId(), elementType);
@@ -269,7 +269,7 @@ public class SchemaUtils {
         case MAP:
           Type keyType = toIcebergType(valueSchema.keySchema());
           Type valueType = toIcebergType(valueSchema.valueSchema());
-          if (config.autoCreateForceOptional() || valueSchema.valueSchema().isOptional()) {
+          if (config.schemaForceOptional() || valueSchema.valueSchema().isOptional()) {
             return MapType.ofOptional(nextId(), nextId(), keyType, valueType);
           } else {
             return MapType.ofRequired(nextId(), nextId(), keyType, valueType);
@@ -281,7 +281,7 @@ public class SchemaUtils {
                       field ->
                           NestedField.of(
                               nextId(),
-                              config.autoCreateForceOptional() || field.schema().isOptional(),
+                              config.schemaForceOptional() || field.schema().isOptional(),
                               field.name(),
                               toIcebergType(field.schema())))
                   .collect(toList());

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUtils.java
@@ -210,18 +210,24 @@ public class SchemaUtils {
     return Pair.of(parts[0].trim(), Integer.parseInt(parts[1].trim()));
   }
 
-  public static Type toIcebergType(Schema valueSchema) {
-    return new SchemaGenerator().toIcebergType(valueSchema);
+  public static Type toIcebergType(Schema valueSchema, IcebergSinkConfig config) {
+    return new SchemaGenerator(config).toIcebergType(valueSchema);
   }
 
-  public static Type inferIcebergType(Object value) {
-    return new SchemaGenerator().inferIcebergType(value);
+  public static Type inferIcebergType(Object value, IcebergSinkConfig config) {
+    return new SchemaGenerator(config).inferIcebergType(value);
   }
 
   static class SchemaGenerator {
 
     private int fieldId = 1;
+    private final IcebergSinkConfig config;
 
+    SchemaGenerator(IcebergSinkConfig config) {
+      this.config = config;
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     Type toIcebergType(Schema valueSchema) {
       switch (valueSchema.type()) {
         case BOOLEAN:
@@ -255,7 +261,7 @@ public class SchemaUtils {
           return DoubleType.get();
         case ARRAY:
           Type elementType = toIcebergType(valueSchema.valueSchema());
-          if (valueSchema.valueSchema().isOptional()) {
+          if (config.autoCreateForceOptional() || valueSchema.valueSchema().isOptional()) {
             return ListType.ofOptional(nextId(), elementType);
           } else {
             return ListType.ofRequired(nextId(), elementType);
@@ -263,7 +269,7 @@ public class SchemaUtils {
         case MAP:
           Type keyType = toIcebergType(valueSchema.keySchema());
           Type valueType = toIcebergType(valueSchema.valueSchema());
-          if (valueSchema.valueSchema().isOptional()) {
+          if (config.autoCreateForceOptional() || valueSchema.valueSchema().isOptional()) {
             return MapType.ofOptional(nextId(), nextId(), keyType, valueType);
           } else {
             return MapType.ofRequired(nextId(), nextId(), keyType, valueType);
@@ -275,7 +281,7 @@ public class SchemaUtils {
                       field ->
                           NestedField.of(
                               nextId(),
-                              field.schema().isOptional(),
+                              config.autoCreateForceOptional() || field.schema().isOptional(),
                               field.name(),
                               toIcebergType(field.schema())))
                   .collect(toList());

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.data.SchemaUpdate.AddColumn;
 import io.tabular.iceberg.connect.data.SchemaUpdate.UpdateType;
 import java.math.BigDecimal;
@@ -153,22 +154,24 @@ public class RecordConverterTest {
   private static final List<String> LIST_VAL = ImmutableList.of("hello", "world");
   private static final Map<String, String> MAP_VAL = ImmutableMap.of("one", "1", "two", "2");
 
-  private static final JsonConverter JSON_CONVERTER = new JsonConverter();
+  private static final IcebergSinkConfig CONFIG = mock(IcebergSinkConfig.class);
 
   static {
-    JSON_CONVERTER.configure(
+    JsonConverter jsonConverter = new JsonConverter();
+    jsonConverter.configure(
         ImmutableMap.of(
             JsonConverterConfig.SCHEMAS_ENABLE_CONFIG,
             false,
             ConverterConfig.TYPE_CONFIG,
             ConverterType.VALUE.getName()));
+    when(CONFIG.jsonConverter()).thenReturn(jsonConverter);
   }
 
   @Test
   public void testMapConvert() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Map<String, Object> data = createMapData();
     Record record = converter.convert(data);
@@ -179,7 +182,7 @@ public class RecordConverterTest {
   public void testNestedMapConvert() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(NESTED_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Map<String, Object> nestedData = createNestedMapData();
     Record record = converter.convert(nestedData);
@@ -191,7 +194,7 @@ public class RecordConverterTest {
   public void testMapToString() throws Exception {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Map<String, Object> nestedData = createNestedMapData();
     Record record = converter.convert(nestedData);
@@ -205,7 +208,7 @@ public class RecordConverterTest {
   public void testStructConvert() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Struct data = createStructData();
     Record record = converter.convert(data);
@@ -216,7 +219,7 @@ public class RecordConverterTest {
   public void testNestedStructConvert() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(NESTED_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Struct nestedData = createNestedStructData();
     Record record = converter.convert(nestedData);
@@ -228,7 +231,7 @@ public class RecordConverterTest {
   public void testStructToString() throws Exception {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Struct nestedData = createNestedStructData();
     Record record = converter.convert(nestedData);
@@ -249,7 +252,7 @@ public class RecordConverterTest {
             ImmutableMap.of(
                 TableProperties.DEFAULT_NAME_MAPPING, NameMappingParser.toJson(nameMapping)));
 
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Map<String, Object> data = ImmutableMap.of("renamed_ii", 123);
     Record record = converter.convert(data);
@@ -260,7 +263,7 @@ public class RecordConverterTest {
   public void testDecimalConversion() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     BigDecimal expected = new BigDecimal("123.45");
 
@@ -285,7 +288,7 @@ public class RecordConverterTest {
   public void testDateConversion() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     LocalDate expected = LocalDate.of(2023, 11, 15);
 
@@ -307,7 +310,7 @@ public class RecordConverterTest {
   public void testTimeConversion() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     LocalTime expected = LocalTime.of(7, 51, 30, 888_000_000);
 
@@ -342,7 +345,7 @@ public class RecordConverterTest {
   private void convertToTimestamps(Temporal expected, long expectedMillis, TimestampType type) {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     List<Object> inputList =
         ImmutableList.of(
@@ -372,7 +375,7 @@ public class RecordConverterTest {
   public void testMissingColumnDetectionMap() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(ID_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Map<String, Object> data = Maps.newHashMap(createMapData());
     data.put("null", null);
@@ -410,7 +413,7 @@ public class RecordConverterTest {
   public void testMissingColumnDetectionMapNested() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(ID_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Map<String, Object> nestedData = createNestedMapData();
     List<SchemaUpdate> addCols = Lists.newArrayList();
@@ -446,7 +449,7 @@ public class RecordConverterTest {
   public void testMissingColumnDetectionStruct() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(ID_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Struct data = createStructData();
     List<SchemaUpdate> updates = Lists.newArrayList();
@@ -484,7 +487,7 @@ public class RecordConverterTest {
 
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(tableSchema);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Schema valueSchema =
         SchemaBuilder.struct().field("ii", Schema.INT64_SCHEMA).field("ff", Schema.FLOAT64_SCHEMA);
@@ -518,7 +521,7 @@ public class RecordConverterTest {
 
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(tableSchema);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Schema structSchema =
         SchemaBuilder.struct().field("ii", Schema.INT64_SCHEMA).field("ff", Schema.FLOAT64_SCHEMA);
@@ -545,7 +548,7 @@ public class RecordConverterTest {
   public void testMissingColumnDetectionStructNested() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(ID_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, JSON_CONVERTER);
+    RecordConverter converter = new RecordConverter(table, CONFIG);
 
     Struct nestedData = createNestedStructData();
     List<SchemaUpdate> addCols = Lists.newArrayList();

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/SchemaUtilsTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/SchemaUtilsTest.java
@@ -66,6 +66,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class SchemaUtilsTest {
 
@@ -82,8 +84,6 @@ public class SchemaUtilsTest {
           NestedField.required(4, "ts2", TimestampType.withZone()),
           NestedField.required(5, "ts3", TimestampType.withZone()),
           NestedField.required(6, "ts4", TimestampType.withZone()));
-
-  private static final IcebergSinkConfig CONFIG = mock(IcebergSinkConfig.class);
 
   @Test
   public void testApplySchemaUpdates() {
@@ -166,89 +166,98 @@ public class SchemaUtilsTest {
     assertThat(spec.fields()).anyMatch(val -> val.transform().toString().startsWith("identity"));
   }
 
-  @Test
-  public void testToIcebergType() {
-    assertThat(SchemaUtils.toIcebergType(Schema.BOOLEAN_SCHEMA, CONFIG))
-        .isInstanceOf(BooleanType.class);
-    assertThat(SchemaUtils.toIcebergType(Schema.BYTES_SCHEMA, CONFIG))
-        .isInstanceOf(BinaryType.class);
-    assertThat(SchemaUtils.toIcebergType(Schema.INT8_SCHEMA, CONFIG))
-        .isInstanceOf(IntegerType.class);
-    assertThat(SchemaUtils.toIcebergType(Schema.INT16_SCHEMA, CONFIG))
-        .isInstanceOf(IntegerType.class);
-    assertThat(SchemaUtils.toIcebergType(Schema.INT32_SCHEMA, CONFIG))
-        .isInstanceOf(IntegerType.class);
-    assertThat(SchemaUtils.toIcebergType(Schema.INT64_SCHEMA, CONFIG)).isInstanceOf(LongType.class);
-    assertThat(SchemaUtils.toIcebergType(Schema.FLOAT32_SCHEMA, CONFIG))
-        .isInstanceOf(FloatType.class);
-    assertThat(SchemaUtils.toIcebergType(Schema.FLOAT64_SCHEMA, CONFIG))
-        .isInstanceOf(DoubleType.class);
-    assertThat(SchemaUtils.toIcebergType(Schema.STRING_SCHEMA, CONFIG))
-        .isInstanceOf(StringType.class);
-    assertThat(SchemaUtils.toIcebergType(Date.SCHEMA, CONFIG)).isInstanceOf(DateType.class);
-    assertThat(SchemaUtils.toIcebergType(Time.SCHEMA, CONFIG)).isInstanceOf(TimeType.class);
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testToIcebergType(boolean forceOptional) {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateForceOptional()).thenReturn(forceOptional);
 
-    Type timestampType = SchemaUtils.toIcebergType(Timestamp.SCHEMA, CONFIG);
+    assertThat(SchemaUtils.toIcebergType(Schema.BOOLEAN_SCHEMA, config))
+        .isInstanceOf(BooleanType.class);
+    assertThat(SchemaUtils.toIcebergType(Schema.BYTES_SCHEMA, config))
+        .isInstanceOf(BinaryType.class);
+    assertThat(SchemaUtils.toIcebergType(Schema.INT8_SCHEMA, config))
+        .isInstanceOf(IntegerType.class);
+    assertThat(SchemaUtils.toIcebergType(Schema.INT16_SCHEMA, config))
+        .isInstanceOf(IntegerType.class);
+    assertThat(SchemaUtils.toIcebergType(Schema.INT32_SCHEMA, config))
+        .isInstanceOf(IntegerType.class);
+    assertThat(SchemaUtils.toIcebergType(Schema.INT64_SCHEMA, config)).isInstanceOf(LongType.class);
+    assertThat(SchemaUtils.toIcebergType(Schema.FLOAT32_SCHEMA, config))
+        .isInstanceOf(FloatType.class);
+    assertThat(SchemaUtils.toIcebergType(Schema.FLOAT64_SCHEMA, config))
+        .isInstanceOf(DoubleType.class);
+    assertThat(SchemaUtils.toIcebergType(Schema.STRING_SCHEMA, config))
+        .isInstanceOf(StringType.class);
+    assertThat(SchemaUtils.toIcebergType(Date.SCHEMA, config)).isInstanceOf(DateType.class);
+    assertThat(SchemaUtils.toIcebergType(Time.SCHEMA, config)).isInstanceOf(TimeType.class);
+
+    Type timestampType = SchemaUtils.toIcebergType(Timestamp.SCHEMA, config);
     assertThat(timestampType).isInstanceOf(TimestampType.class);
     assertThat(((TimestampType) timestampType).shouldAdjustToUTC()).isTrue();
 
-    Type decimalType = SchemaUtils.toIcebergType(Decimal.schema(4), CONFIG);
+    Type decimalType = SchemaUtils.toIcebergType(Decimal.schema(4), config);
     assertThat(decimalType).isInstanceOf(DecimalType.class);
     assertThat(((DecimalType) decimalType).scale()).isEqualTo(4);
 
     Type listType =
-        SchemaUtils.toIcebergType(SchemaBuilder.array(Schema.STRING_SCHEMA).build(), CONFIG);
+        SchemaUtils.toIcebergType(SchemaBuilder.array(Schema.STRING_SCHEMA).build(), config);
     assertThat(listType).isInstanceOf(ListType.class);
     assertThat(listType.asListType().elementType()).isInstanceOf(StringType.class);
+    assertThat(listType.asListType().isElementOptional()).isEqualTo(forceOptional);
 
     Type mapType =
         SchemaUtils.toIcebergType(
-            SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build(), CONFIG);
+            SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build(), config);
     assertThat(mapType).isInstanceOf(MapType.class);
     assertThat(mapType.asMapType().keyType()).isInstanceOf(StringType.class);
     assertThat(mapType.asMapType().valueType()).isInstanceOf(StringType.class);
+    assertThat(mapType.asMapType().isValueOptional()).isEqualTo(forceOptional);
 
     Type structType =
         SchemaUtils.toIcebergType(
-            SchemaBuilder.struct().field("i", Schema.INT32_SCHEMA).build(), CONFIG);
+            SchemaBuilder.struct().field("i", Schema.INT32_SCHEMA).build(), config);
     assertThat(structType).isInstanceOf(StructType.class);
     assertThat(structType.asStructType().fieldType("i")).isInstanceOf(IntegerType.class);
+    assertThat(structType.asStructType().field("i").isOptional()).isEqualTo(forceOptional);
   }
 
   @Test
   public void testInferIcebergType() {
-    assertThatThrownBy(() -> SchemaUtils.inferIcebergType(null, CONFIG))
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+
+    assertThatThrownBy(() -> SchemaUtils.inferIcebergType(null, config))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Cannot infer type from null value");
 
-    assertThat(SchemaUtils.inferIcebergType(1, CONFIG)).isInstanceOf(LongType.class);
-    assertThat(SchemaUtils.inferIcebergType(1L, CONFIG)).isInstanceOf(LongType.class);
-    assertThat(SchemaUtils.inferIcebergType(1.1f, CONFIG)).isInstanceOf(DoubleType.class);
-    assertThat(SchemaUtils.inferIcebergType(1.1d, CONFIG)).isInstanceOf(DoubleType.class);
-    assertThat(SchemaUtils.inferIcebergType("foobar", CONFIG)).isInstanceOf(StringType.class);
-    assertThat(SchemaUtils.inferIcebergType(true, CONFIG)).isInstanceOf(BooleanType.class);
-    assertThat(SchemaUtils.inferIcebergType(LocalDate.now(), CONFIG)).isInstanceOf(DateType.class);
-    assertThat(SchemaUtils.inferIcebergType(LocalTime.now(), CONFIG)).isInstanceOf(TimeType.class);
+    assertThat(SchemaUtils.inferIcebergType(1, config)).isInstanceOf(LongType.class);
+    assertThat(SchemaUtils.inferIcebergType(1L, config)).isInstanceOf(LongType.class);
+    assertThat(SchemaUtils.inferIcebergType(1.1f, config)).isInstanceOf(DoubleType.class);
+    assertThat(SchemaUtils.inferIcebergType(1.1d, config)).isInstanceOf(DoubleType.class);
+    assertThat(SchemaUtils.inferIcebergType("foobar", config)).isInstanceOf(StringType.class);
+    assertThat(SchemaUtils.inferIcebergType(true, config)).isInstanceOf(BooleanType.class);
+    assertThat(SchemaUtils.inferIcebergType(LocalDate.now(), config)).isInstanceOf(DateType.class);
+    assertThat(SchemaUtils.inferIcebergType(LocalTime.now(), config)).isInstanceOf(TimeType.class);
 
-    Type timestampType = SchemaUtils.inferIcebergType(new java.util.Date(), CONFIG);
+    Type timestampType = SchemaUtils.inferIcebergType(new java.util.Date(), config);
     assertThat(timestampType).isInstanceOf(TimestampType.class);
     assertThat(((TimestampType) timestampType).shouldAdjustToUTC()).isTrue();
 
-    timestampType = SchemaUtils.inferIcebergType(OffsetDateTime.now(), CONFIG);
+    timestampType = SchemaUtils.inferIcebergType(OffsetDateTime.now(), config);
     assertThat(timestampType).isInstanceOf(TimestampType.class);
     assertThat(((TimestampType) timestampType).shouldAdjustToUTC()).isTrue();
 
-    timestampType = SchemaUtils.inferIcebergType(LocalDateTime.now(), CONFIG);
+    timestampType = SchemaUtils.inferIcebergType(LocalDateTime.now(), config);
     assertThat(timestampType).isInstanceOf(TimestampType.class);
     assertThat(((TimestampType) timestampType).shouldAdjustToUTC()).isFalse();
 
-    Type decimalType = SchemaUtils.inferIcebergType(new BigDecimal("12.345"), CONFIG);
+    Type decimalType = SchemaUtils.inferIcebergType(new BigDecimal("12.345"), config);
     assertThat(decimalType).isInstanceOf(DecimalType.class);
     assertThat(((DecimalType) decimalType).scale()).isEqualTo(3);
 
-    assertThat(SchemaUtils.inferIcebergType(ImmutableList.of("foobar"), CONFIG))
+    assertThat(SchemaUtils.inferIcebergType(ImmutableList.of("foobar"), config))
         .isInstanceOf(ListType.class);
-    assertThat(SchemaUtils.inferIcebergType(ImmutableMap.of("foo", "bar"), CONFIG))
+    assertThat(SchemaUtils.inferIcebergType(ImmutableMap.of("foo", "bar"), config))
         .isInstanceOf(StructType.class);
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/SchemaUtilsTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/SchemaUtilsTest.java
@@ -170,7 +170,7 @@ public class SchemaUtilsTest {
   @ValueSource(booleans = {false, true})
   public void testToIcebergType(boolean forceOptional) {
     IcebergSinkConfig config = mock(IcebergSinkConfig.class);
-    when(config.autoCreateForceOptional()).thenReturn(forceOptional);
+    when(config.schemaForceOptional()).thenReturn(forceOptional);
 
     assertThat(SchemaUtils.toIcebergType(Schema.BOOLEAN_SCHEMA, config))
         .isInstanceOf(BooleanType.class);


### PR DESCRIPTION
This PR adds a new config option, `iceberg.tables.schema-force-optional`, that will set all columns to optional during table auto creation and schema evolution. The default for this is `false` so the required flag from the schema will be respected. This can be useful in cases where multiple topics with different schemas are being combined into a single table.