### PR TITLE
Fix parsing bug for partition spec config

### DIFF
--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/IcebergSinkConfigTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/IcebergSinkConfigTest.java
@@ -21,6 +21,7 @@ package io.tabular.iceberg.connect;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.common.config.ConfigException;
@@ -57,4 +58,34 @@ public class IcebergSinkConfigTest {
     IcebergSinkConfig config = new IcebergSinkConfig(props);
     assertThat(config.commitIntervalMs()).isEqualTo(300_000);
   }
+
+  @Test
+  public void testStringToList() {
+    List<String> result = IcebergSinkConfig.stringToList(null, ",");
+    assertThat(result).isEmpty();
+
+    result = IcebergSinkConfig.stringToList("", ",");
+    assertThat(result).isEmpty();
+
+    result = IcebergSinkConfig.stringToList("one ", ",");
+    assertThat(result).contains("one");
+
+    result = IcebergSinkConfig.stringToList("one, two", ",");
+    assertThat(result).contains("one", "two");
+
+    result = IcebergSinkConfig.stringToList("bucket(id, 4)", ",");
+    assertThat(result).contains("bucket(id", "4)");
+
+    result =
+        IcebergSinkConfig.stringToList("bucket(id, 4)", IcebergSinkConfig.COMMA_NO_PARENS_REGEX);
+    assertThat(result).contains("bucket(id, 4)");
+
+    result =
+        IcebergSinkConfig.stringToList(
+            "bucket(id, 4), type", IcebergSinkConfig.COMMA_NO_PARENS_REGEX);
+    assertThat(result).contains("bucket(id, 4)", "type");
+  }
+
+  @Test
+  public void testStringWithParensToList() {}
 }


### PR DESCRIPTION
This PR fixes an issue parsing the config for partition specs that contain transforms which use commas, such as `bucket` and `truncate`. 