### PR TITLE
Improved handling of null and empty values when inferring schema

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriterFactory.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.Tasks;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +69,10 @@ public class IcebergWriterFactory {
   Table autoCreateTable(String tableName, SinkRecord sample) {
     StructType structType;
     if (sample.valueSchema() == null) {
-      structType = SchemaUtils.inferIcebergType(sample.value(), config).asStructType();
+      structType =
+          SchemaUtils.inferIcebergType(sample.value(), config)
+              .orElseThrow(() -> new DataException("Unable to create table from empty object"))
+              .asStructType();
     } else {
       structType = SchemaUtils.toIcebergType(sample.valueSchema(), config).asStructType();
     }


### PR DESCRIPTION
This PR updates schema inference so that empty values are ignored and are not added as part of table create or schema evolution. Empty values include nulls, lists with no elements, lists with the first element as null, lists with the first element as an empty object, objects with no fields, and objects with all fields set to empty values.

When possible, using a message schema is strongly preferred over relying on schema inference.