### PR TITLE
Add config option to enable case-insensitive column lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.auto-create-enabled         | Set to `true` to automatically create destination tables, default is `false`                                     |
 | iceberg.tables.evolve-schema-enabled       | Set to `true` to add any missing record fields to the table schema, default is `false`                           |
 | iceberg.tables.schema-force-optional       | Set to `true` to set columns as optional during table create and evolution, default is `false` to respect schema |
+| iceberg.tables.schema-case-insensitive     | Set to `true` to look up table columns by case-insensitive name, default is `false` for case-sensitive           |
 | iceberg.tables.auto-create-props.*         | Properties set on new tables during auto-create                                                                  |
 | iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization, these take precedence                                |
 | iceberg.table.\<table name\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                   |

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -77,10 +77,12 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.upsert-mode-enabled";
   private static final String TABLES_AUTO_CREATE_ENABLED_PROP =
       "iceberg.tables.auto-create-enabled";
-  private static final String TABLES_SCHEMA_FORCE_OPTIONAL_PROP =
-      "iceberg.tables.schema-force-optional";
   private static final String TABLES_EVOLVE_SCHEMA_ENABLED_PROP =
       "iceberg.tables.evolve-schema-enabled";
+  private static final String TABLES_SCHEMA_FORCE_OPTIONAL_PROP =
+      "iceberg.tables.schema-force-optional";
+  private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
+      "iceberg.tables.schema-case-insensitive";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PROP = "iceberg.control.group-id";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -175,6 +177,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         false,
         Importance.MEDIUM,
         "Set to true to set columns as optional during table create and evolution, false to respect schema");
+    configDef.define(
+        TABLES_SCHEMA_CASE_INSENSITIVE_PROP,
+        Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        "Set to true to look up table columns by case-insensitive name, false for case-sensitive");
     configDef.define(
         TABLES_EVOLVE_SCHEMA_ENABLED_PROP,
         Type.BOOLEAN,
@@ -427,12 +435,16 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getBoolean(TABLES_AUTO_CREATE_ENABLED_PROP);
   }
 
+  public boolean evolveSchemaEnabled() {
+    return getBoolean(TABLES_EVOLVE_SCHEMA_ENABLED_PROP);
+  }
+
   public boolean schemaForceOptional() {
     return getBoolean(TABLES_SCHEMA_FORCE_OPTIONAL_PROP);
   }
 
-  public boolean evolveSchemaEnabled() {
-    return getBoolean(TABLES_EVOLVE_SCHEMA_ENABLED_PROP);
+  public boolean schemaCaseInsensitive() {
+    return getBoolean(TABLES_SCHEMA_CASE_INSENSITIVE_PROP);
   }
 
   public JsonConverter jsonConverter() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/RecordConverter.java
@@ -250,7 +250,9 @@ public class RecordConverter {
 
   private NestedField lookupStructField(String fieldName, StructType schema, int structFieldId) {
     if (nameMapping == null) {
-      return schema.field(fieldName);
+      return config.schemaCaseInsensitive()
+          ? schema.caseInsensitiveField(fieldName)
+          : schema.field(fieldName);
     }
 
     return structNameMap

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/RecordConverterTest.java
@@ -77,7 +77,10 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.storage.ConverterConfig;
 import org.apache.kafka.connect.storage.ConverterType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class RecordConverterTest {
 
@@ -119,6 +122,11 @@ public class RecordConverterTest {
           Types.NestedField.required(1, "ii", Types.IntegerType.get()),
           Types.NestedField.required(2, "st", Types.StringType.get()));
 
+  private static final org.apache.iceberg.Schema SIMPLE_SCHEMA_UPPER_CASE =
+      new org.apache.iceberg.Schema(
+          Types.NestedField.required(1, "II", Types.IntegerType.get()),
+          Types.NestedField.required(2, "ST", Types.StringType.get()));
+
   private static final org.apache.iceberg.Schema ID_SCHEMA =
       new org.apache.iceberg.Schema(Types.NestedField.required(1, "ii", Types.IntegerType.get()));
 
@@ -154,24 +162,30 @@ public class RecordConverterTest {
   private static final List<String> LIST_VAL = ImmutableList.of("hello", "world");
   private static final Map<String, String> MAP_VAL = ImmutableMap.of("one", "1", "two", "2");
 
-  private static final IcebergSinkConfig CONFIG = mock(IcebergSinkConfig.class);
+  private static final JsonConverter JSON_CONVERTER = new JsonConverter();
 
   static {
-    JsonConverter jsonConverter = new JsonConverter();
-    jsonConverter.configure(
+    JSON_CONVERTER.configure(
         ImmutableMap.of(
             JsonConverterConfig.SCHEMAS_ENABLE_CONFIG,
             false,
             ConverterConfig.TYPE_CONFIG,
             ConverterType.VALUE.getName()));
-    when(CONFIG.jsonConverter()).thenReturn(jsonConverter);
+  }
+
+  private IcebergSinkConfig config;
+
+  @BeforeEach
+  public void before() {
+    this.config = mock(IcebergSinkConfig.class);
+    when(config.jsonConverter()).thenReturn(JSON_CONVERTER);
   }
 
   @Test
   public void testMapConvert() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Map<String, Object> data = createMapData();
     Record record = converter.convert(data);
@@ -182,7 +196,7 @@ public class RecordConverterTest {
   public void testNestedMapConvert() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(NESTED_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Map<String, Object> nestedData = createNestedMapData();
     Record record = converter.convert(nestedData);
@@ -194,7 +208,7 @@ public class RecordConverterTest {
   public void testMapToString() throws Exception {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Map<String, Object> nestedData = createNestedMapData();
     Record record = converter.convert(nestedData);
@@ -208,7 +222,7 @@ public class RecordConverterTest {
   public void testStructConvert() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Struct data = createStructData();
     Record record = converter.convert(data);
@@ -219,7 +233,7 @@ public class RecordConverterTest {
   public void testNestedStructConvert() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(NESTED_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Struct nestedData = createNestedStructData();
     Record record = converter.convert(nestedData);
@@ -231,7 +245,7 @@ public class RecordConverterTest {
   public void testStructToString() throws Exception {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Struct nestedData = createNestedStructData();
     Record record = converter.convert(nestedData);
@@ -252,18 +266,39 @@ public class RecordConverterTest {
             ImmutableMap.of(
                 TableProperties.DEFAULT_NAME_MAPPING, NameMappingParser.toJson(nameMapping)));
 
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Map<String, Object> data = ImmutableMap.of("renamed_ii", 123);
     Record record = converter.convert(data);
     assertThat(record.getField("ii")).isEqualTo(123);
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testCaseSensitivity(boolean caseInsensitive) {
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(SIMPLE_SCHEMA_UPPER_CASE);
+
+    when(config.schemaCaseInsensitive()).thenReturn(caseInsensitive);
+
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Map<String, Object> data = ImmutableMap.of("ii", 123);
+    Record record = converter.convert(data);
+
+    if (caseInsensitive) {
+      assertThat(record.getField("II")).isEqualTo(123);
+    } else {
+      assertThat(record.getField("II")).isEqualTo(null);
+    }
+  }
+
   @Test
   public void testDecimalConversion() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+
+    RecordConverter converter = new RecordConverter(table, config);
 
     BigDecimal expected = new BigDecimal("123.45");
 
@@ -288,7 +323,7 @@ public class RecordConverterTest {
   public void testDateConversion() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     LocalDate expected = LocalDate.of(2023, 11, 15);
 
@@ -310,7 +345,7 @@ public class RecordConverterTest {
   public void testTimeConversion() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     LocalTime expected = LocalTime.of(7, 51, 30, 888_000_000);
 
@@ -345,7 +380,7 @@ public class RecordConverterTest {
   private void convertToTimestamps(Temporal expected, long expectedMillis, TimestampType type) {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     List<Object> inputList =
         ImmutableList.of(
@@ -375,7 +410,7 @@ public class RecordConverterTest {
   public void testMissingColumnDetectionMap() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(ID_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Map<String, Object> data = Maps.newHashMap(createMapData());
     data.put("null", null);
@@ -413,7 +448,7 @@ public class RecordConverterTest {
   public void testMissingColumnDetectionMapNested() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(ID_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Map<String, Object> nestedData = createNestedMapData();
     List<SchemaUpdate> addCols = Lists.newArrayList();
@@ -449,7 +484,7 @@ public class RecordConverterTest {
   public void testMissingColumnDetectionStruct() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(ID_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Struct data = createStructData();
     List<SchemaUpdate> updates = Lists.newArrayList();
@@ -487,7 +522,7 @@ public class RecordConverterTest {
 
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(tableSchema);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Schema valueSchema =
         SchemaBuilder.struct().field("ii", Schema.INT64_SCHEMA).field("ff", Schema.FLOAT64_SCHEMA);
@@ -521,7 +556,7 @@ public class RecordConverterTest {
 
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(tableSchema);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Schema structSchema =
         SchemaBuilder.struct().field("ii", Schema.INT64_SCHEMA).field("ff", Schema.FLOAT64_SCHEMA);
@@ -548,7 +583,7 @@ public class RecordConverterTest {
   public void testMissingColumnDetectionStructNested() {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(ID_SCHEMA);
-    RecordConverter converter = new RecordConverter(table, CONFIG);
+    RecordConverter converter = new RecordConverter(table, config);
 
     Struct nestedData = createNestedStructData();
     List<SchemaUpdate> addCols = Lists.newArrayList();


### PR DESCRIPTION
During conversion from Kafka record to Iceberg record, fields are matched based on the field name in the schema. Currently the field name lookup in the schema is case-sensitive. This PR adds the config option`iceberg.tables.schema-case-insensitive` to allow this lookup to be case-insensitive.

Note that lookups can also use Iceberg's [name mapping](https://iceberg.apache.org/spec/#name-mapping-serialization) feature, and this is still always case-sensitive.