### PR TITLE
Fixes for schema evolution with structs in collections

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -19,6 +19,7 @@
 package io.tabular.iceberg.connect.data;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
+import io.tabular.iceberg.connect.data.SchemaUpdate.Consumer;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
@@ -82,10 +83,10 @@ public class IcebergWriter implements RecordWriter {
       return recordConverter.convert(record.value());
     }
 
-    List<SchemaUpdate> updates = Lists.newArrayList();
-    Record row = recordConverter.convert(record.value(), updates::add);
+    SchemaUpdate.Consumer updates = new Consumer();
+    Record row = recordConverter.convert(record.value(), updates);
 
-    if (!updates.isEmpty()) {
+    if (!updates.empty()) {
       // complete the current file
       flush();
       // apply the schema updates, this will refresh the table
@@ -93,7 +94,7 @@ public class IcebergWriter implements RecordWriter {
       // initialize a new writer with the new schema
       initNewWriter();
       // convert the row again, this time using the new table schema
-      row = recordConverter.convert(record.value(), updates::add);
+      row = recordConverter.convert(record.value(), null);
     }
 
     return row;

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUpdate.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/SchemaUpdate.java
@@ -18,10 +18,48 @@
  */
 package io.tabular.iceberg.connect.data;
 
+import java.util.Collection;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Type.PrimitiveType;
 
 public class SchemaUpdate {
+
+  public static class Consumer {
+    private final Map<String, AddColumn> addColumns = Maps.newHashMap();
+    private final Map<String, UpdateType> updateTypes = Maps.newHashMap();
+    private final Map<String, MakeOptional> makeOptionals = Maps.newHashMap();
+
+    public Collection<AddColumn> addColumns() {
+      return addColumns.values();
+    }
+
+    public Collection<UpdateType> updateTypes() {
+      return updateTypes.values();
+    }
+
+    public Collection<MakeOptional> makeOptionals() {
+      return makeOptionals.values();
+    }
+
+    public boolean empty() {
+      return addColumns.isEmpty() && updateTypes.isEmpty() && makeOptionals.isEmpty();
+    }
+
+    public void addColumn(String parentName, String name, Type type) {
+      AddColumn addCol = new AddColumn(parentName, name, type);
+      addColumns.put(addCol.key(), addCol);
+    }
+
+    public void updateType(String name, PrimitiveType type) {
+      updateTypes.put(name, new UpdateType(name, type));
+    }
+
+    public void makeOptional(String name) {
+      makeOptionals.put(name, new MakeOptional(name));
+    }
+  }
 
   public static class AddColumn extends SchemaUpdate {
     private final String parentName;
@@ -40,6 +78,10 @@ public class SchemaUpdate {
 
     public String name() {
       return name;
+    }
+
+    public String key() {
+      return parentName == null ? name : parentName + "." + name;
     }
 
     public Type type() {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/SchemaUtilsTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/SchemaUtilsTest.java
@@ -30,9 +30,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
-import io.tabular.iceberg.connect.data.SchemaUpdate.AddColumn;
-import io.tabular.iceberg.connect.data.SchemaUpdate.MakeOptional;
-import io.tabular.iceberg.connect.data.SchemaUpdate.UpdateType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -105,15 +102,14 @@ public class SchemaUtilsTest {
     when(table.updateSchema()).thenReturn(updateSchema);
 
     // the updates to "i" should be ignored as it already exists and is the same type
-    List<SchemaUpdate> updates =
-        ImmutableList.of(
-            new AddColumn(null, "i", IntegerType.get()),
-            new UpdateType("i", IntegerType.get()),
-            new MakeOptional("i"),
-            new UpdateType("f", DoubleType.get()),
-            new AddColumn(null, "s", StringType.get()));
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    consumer.addColumn(null, "i", IntegerType.get());
+    consumer.updateType("i", IntegerType.get());
+    consumer.makeOptional("i");
+    consumer.updateType("f", DoubleType.get());
+    consumer.addColumn(null, "s", StringType.get());
 
-    SchemaUtils.applySchemaUpdates(table, updates);
+    SchemaUtils.applySchemaUpdates(table, consumer);
     verify(table).refresh();
     verify(table).updateSchema();
 
@@ -136,15 +132,14 @@ public class SchemaUtilsTest {
     when(table.updateSchema()).thenReturn(updateSchema);
 
     // the updates to "st.i" should be ignored as it already exists and is the same type
-    List<SchemaUpdate> updates =
-        ImmutableList.of(
-            new AddColumn("st", "i", IntegerType.get()),
-            new UpdateType("st.i", IntegerType.get()),
-            new MakeOptional("st.i"),
-            new UpdateType("st.f", DoubleType.get()),
-            new AddColumn("st", "s", StringType.get()));
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    consumer.addColumn("st", "i", IntegerType.get());
+    consumer.updateType("st.i", IntegerType.get());
+    consumer.makeOptional("st.i");
+    consumer.updateType("st.f", DoubleType.get());
+    consumer.addColumn("st", "s", StringType.get());
 
-    SchemaUtils.applySchemaUpdates(table, updates);
+    SchemaUtils.applySchemaUpdates(table, consumer);
     verify(table).refresh();
     verify(table).updateSchema();
 
@@ -168,7 +163,7 @@ public class SchemaUtilsTest {
     verify(table, times(0)).refresh();
     verify(table, times(0)).updateSchema();
 
-    SchemaUtils.applySchemaUpdates(table, ImmutableList.of());
+    SchemaUtils.applySchemaUpdates(table, new SchemaUpdate.Consumer());
     verify(table, times(0)).refresh();
     verify(table, times(0)).updateSchema();
   }


### PR DESCRIPTION
This PR fixes schema evolution for list types with struct element types and map types with struct value types. Previously, add column commands were generated for each struct element in the collection. If the collection size was greater than one, then multiple add column commands were generated for the same struct. The schema update would then fail due to duplicate column names.