### PR TITLE
Feature: adding default database for dynamic table routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.tables.schema-case-insensitive     | Set to `true` to look up table columns by case-insensitive name, default is `false` for case-sensitive           |
 | iceberg.tables.auto-create-props.*         | Properties set on new tables during auto-create                                                                  |
 | iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization, these take precedence                                |
+| iceberg.tables.default-database            | Default database name to be prepended to the values of the field specified in `iceberg.tables.route-field`       |
 | iceberg.table.\<table name\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                   |
 | iceberg.table.\<table name\>.id-columns    | Comma-separated list of columns that identify a row in the table (primary key)                                   |
 | iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                          |

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -291,6 +291,10 @@ public class IcebergSinkConfig extends AbstractConfig {
     } else {
       throw new ConfigException("Must specify table name(s)");
     }
+    if (tablesDefaultDatabase() != null) {
+      checkState(dynamicTablesEnabled(), "Default database setting must be used with dynamic tables");
+      checkState(tables() == null, "Cannot specify both tables and default database");
+    }
   }
 
   private void checkState(boolean condition, String msg) {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -83,6 +83,7 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.schema-force-optional";
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
+  private static final String TABLES_DEFAULT_DATABASE_PROP = "iceberg.tables.default-database";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PROP = "iceberg.control.group-id";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -189,6 +190,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         false,
         Importance.MEDIUM,
         "Set to true to add any missing record fields to the table schema, false otherwise");
+    configDef.define(
+        TABLES_DEFAULT_DATABASE_PROP,
+        Type.STRING,
+        null,
+        Importance.MEDIUM,
+        "Default database identifier to be prefixed to the table names");
     configDef.define(
         CATALOG_NAME_PROP,
         Type.STRING,
@@ -347,6 +354,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public String tablesDefaultPartitionBy() {
     return getString(TABLES_DEFAULT_PARTITION_BY);
+  }
+
+  public String tablesDefaultDatabase() {
+    return getString(TABLES_DEFAULT_DATABASE_PROP);
   }
 
   public TableSinkConfig tableConfig(String tableName) {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -292,7 +292,8 @@ public class IcebergSinkConfig extends AbstractConfig {
       throw new ConfigException("Must specify table name(s)");
     }
     if (tablesDefaultDatabase() != null) {
-      checkState(dynamicTablesEnabled(), "Default database setting must be used with dynamic tables");
+      checkState(
+          dynamicTablesEnabled(), "Default database setting must be used with dynamic tables");
       checkState(tables() == null, "Cannot specify both tables and default database");
     }
   }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -219,12 +219,18 @@ public class Worker extends Channel {
 
   private void routeRecordDynamically(SinkRecord record) {
     String routeField = config.tablesRouteField();
+    String defaultDatabase = config.tablesDefaultDatabase();
     Preconditions.checkNotNull(routeField, "Route field cannot be null with dynamic routing");
 
     String routeValue = extractRouteValue(record.value(), routeField);
     if (routeValue != null) {
-      String tableName = routeValue.toLowerCase();
-      writerForTable(tableName, record, true).write(record);
+        String tableName;
+        if (defaultDatabase != null) {
+            tableName = defaultDatabase + "." + routeValue.toLowerCase();
+        } else {
+            tableName = routeValue.toLowerCase();
+        }
+        writerForTable(tableName, record, true).write(record);
     }
   }
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -224,13 +224,13 @@ public class Worker extends Channel {
 
     String routeValue = extractRouteValue(record.value(), routeField);
     if (routeValue != null) {
-        String tableName;
-        if (defaultDatabase != null) {
-            tableName = defaultDatabase + "." + routeValue.toLowerCase();
-        } else {
-            tableName = routeValue.toLowerCase();
-        }
-        writerForTable(tableName, record, true).write(record);
+      String tableName;
+      if (defaultDatabase != null) {
+        tableName = defaultDatabase + "." + routeValue.toLowerCase();
+      } else {
+        tableName = routeValue.toLowerCase();
+      }
+      writerForTable(tableName, record, true).write(record);
     }
   }
 


### PR DESCRIPTION
Hi team, adding this PR to allow the default database name to be prepended to the values in `iceberg.tables.route-field`. 

This resolves a current issue in Trainline's setup where we have a field to be used for dynamic routing but it doesn't have the database name in it. Previously using this field would have thrown `org.apache.iceberg.exceptions.NoSuchTableException: Invalid table identifier: table_name` error.