### PR TITLE
Update commons-compress library version

### DIFF
--- a/kafka-connect-runtime/build.gradle
+++ b/kafka-connect-runtime/build.gradle
@@ -9,7 +9,7 @@ configurations {
   all {
     resolutionStrategy.force "org.codehaus.jettison:jettison:1.5.4"
     resolutionStrategy.force "org.xerial.snappy:snappy-java:1.1.10.5"
-    resolutionStrategy.force "org.apache.commons:commons-compress:1.24.0"
+    resolutionStrategy.force "org.apache.commons:commons-compress:1.26.0"
     resolutionStrategy.force "org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1-tabular"
     resolutionStrategy.eachDependency { details ->
       if (details.requested.group == "io.netty") {


### PR DESCRIPTION
`org.apache.commons:commons-compress:1.24.0` has been reported for vulnerabilities: 
- CVE-2024-25710
- CVE-2024-26308

`org.apache.commons:commons-compress:1.26.0` fixes these. 

# Previously

```bash
./gradlew -q iceberg-kafka-connect-runtime:dependencyInsight --dependency commons-compress --configuration runtimeClassPath
org.apache.commons:commons-compress:1.24.0 (forced)
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 8            |

org.apache.commons:commons-compress:1.21 -> 1.24.0
\--- org.apache.hadoop:hadoop-common:3.3.6
     \--- runtimeClasspath

org.apache.commons:commons-compress:1.22 -> 1.24.0
\--- org.apache.avro:avro:1.11.3
     +--- project :iceberg-kafka-connect
     |    \--- runtimeClasspath
     +--- project :iceberg-kafka-connect-events
     |    \--- project :iceberg-kafka-connect (*)
     +--- org.apache.iceberg:iceberg-orc:1.4.2 (requested org.apache.avro:avro:1.11.1)
     |    \--- project :iceberg-kafka-connect (*)
     \--- org.apache.iceberg:iceberg-core:1.4.2 (requested org.apache.avro:avro:1.11.1)
          +--- project :iceberg-kafka-connect (*)
          +--- org.apache.iceberg:iceberg-aws:1.4.2
          |    \--- runtimeClasspath
          +--- org.apache.iceberg:iceberg-azure:1.4.2
          |    \--- runtimeClasspath
          +--- org.apache.iceberg:iceberg-gcp:1.4.2
          |    \--- runtimeClasspath
          +--- org.apache.iceberg:iceberg-nessie:1.4.2
          |    \--- runtimeClasspath
          +--- project :iceberg-kafka-connect-events (*)
          +--- org.apache.iceberg:iceberg-data:1.4.2
          |    \--- project :iceberg-kafka-connect (*)
          +--- org.apache.iceberg:iceberg-orc:1.4.2 (*)
          \--- org.apache.iceberg:iceberg-parquet:1.4.2
               \--- project :iceberg-kafka-connect (*)

(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.
```


# After this change
```bash 
./gradlew -q iceberg-kafka-connect-runtime:dependencyInsight --dependency commons-compress --configuration runtimeClassPath

org.apache.commons:commons-compress:1.26.0 (forced)
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 8            |

org.apache.commons:commons-compress:1.21 -> 1.26.0
\--- org.apache.hadoop:hadoop-common:3.3.6
     \--- runtimeClasspath

org.apache.commons:commons-compress:1.22 -> 1.26.0
\--- org.apache.avro:avro:1.11.3
     +--- project :iceberg-kafka-connect
     |    \--- runtimeClasspath
     +--- project :iceberg-kafka-connect-events
     |    \--- project :iceberg-kafka-connect (*)
     +--- org.apache.iceberg:iceberg-orc:1.4.2 (requested org.apache.avro:avro:1.11.1)
     |    \--- project :iceberg-kafka-connect (*)
     \--- org.apache.iceberg:iceberg-core:1.4.2 (requested org.apache.avro:avro:1.11.1)
          +--- project :iceberg-kafka-connect (*)
          +--- org.apache.iceberg:iceberg-aws:1.4.2
          |    \--- runtimeClasspath
          +--- org.apache.iceberg:iceberg-azure:1.4.2
          |    \--- runtimeClasspath
          +--- org.apache.iceberg:iceberg-gcp:1.4.2
          |    \--- runtimeClasspath
          +--- org.apache.iceberg:iceberg-nessie:1.4.2
          |    \--- runtimeClasspath
          +--- project :iceberg-kafka-connect-events (*)
          +--- org.apache.iceberg:iceberg-data:1.4.2
          |    \--- project :iceberg-kafka-connect (*)
          +--- org.apache.iceberg:iceberg-orc:1.4.2 (*)
          \--- org.apache.iceberg:iceberg-parquet:1.4.2
               \--- project :iceberg-kafka-connect (*)

(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.
```