### PR TITLE
Refactor ChannelTestBase to replace mocks

### DIFF
--- a/kafka-connect-events/src/test/java/io/tabular/iceberg/connect/events/EventSerializationTest.java
+++ b/kafka-connect-events/src/test/java/io/tabular/iceberg/connect/events/EventSerializationTest.java
@@ -65,9 +65,9 @@ public class EventSerializationTest {
     assertThat(payload.commitId()).isEqualTo(commitId);
     assertThat(payload.tableName().toIdentifier()).isEqualTo(TableIdentifier.parse("db.tbl"));
     assertThat(payload.dataFiles()).hasSize(2);
-    assertThat(payload.dataFiles()).allMatch(f -> f.specId() == 1);
+    assertThat(payload.dataFiles()).allMatch(f -> f.specId() == 0);
     assertThat(payload.deleteFiles()).hasSize(2);
-    assertThat(payload.deleteFiles()).allMatch(f -> f.specId() == 1);
+    assertThat(payload.deleteFiles()).allMatch(f -> f.specId() == 0);
   }
 
   @Test

--- a/kafka-connect-events/src/testFixtures/java/io/tabular/iceberg/connect/events/EventTestUtil.java
+++ b/kafka-connect-events/src/testFixtures/java/io/tabular/iceberg/connect/events/EventTestUtil.java
@@ -18,102 +18,31 @@
  */
 package io.tabular.iceberg.connect.events;
 
-import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.List;
+import java.util.UUID;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Metrics;
-import org.apache.iceberg.PartitionData;
-import org.apache.iceberg.common.DynConstructors;
-import org.apache.iceberg.common.DynConstructors.Ctor;
-import org.apache.iceberg.types.Types.NestedField;
-import org.apache.iceberg.types.Types.StringType;
-import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
 
 public class EventTestUtil {
   public static DataFile createDataFile() {
-    Ctor<DataFile> ctor =
-        DynConstructors.builder(DataFile.class)
-            .hiddenImpl(
-                "org.apache.iceberg.GenericDataFile",
-                int.class,
-                String.class,
-                FileFormat.class,
-                PartitionData.class,
-                long.class,
-                Metrics.class,
-                ByteBuffer.class,
-                List.class,
-                int[].class,
-                Integer.class)
-            .build();
-
-    PartitionData partitionData =
-        new PartitionData(StructType.of(NestedField.required(999, "type", StringType.get())));
-    Metrics metrics =
-        new Metrics(
-            1L,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap());
-
-    return ctor.newInstance(
-        1,
-        "path",
-        FileFormat.PARQUET,
-        partitionData,
-        1L,
-        metrics,
-        ByteBuffer.wrap(new byte[] {0}),
-        null,
-        null,
-        1);
+    return DataFiles.builder(PartitionSpec.unpartitioned())
+        .withPath(UUID.randomUUID() + ".parquet")
+        .withFormat(FileFormat.PARQUET)
+        .withFileSizeInBytes(100L)
+        .withRecordCount(5)
+        .build();
   }
 
   public static DeleteFile createDeleteFile() {
-    Ctor<DeleteFile> ctor =
-        DynConstructors.builder(DeleteFile.class)
-            .hiddenImpl(
-                "org.apache.iceberg.GenericDeleteFile",
-                int.class,
-                FileContent.class,
-                String.class,
-                FileFormat.class,
-                PartitionData.class,
-                long.class,
-                Metrics.class,
-                int[].class,
-                Integer.class,
-                List.class,
-                ByteBuffer.class)
-            .build();
-
-    PartitionData partitionData =
-        new PartitionData(StructType.of(NestedField.required(999, "type", StringType.get())));
-    Metrics metrics =
-        new Metrics(
-            1L,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap());
-
-    return ctor.newInstance(
-        1,
-        FileContent.EQUALITY_DELETES,
-        "path",
-        FileFormat.PARQUET,
-        partitionData,
-        1L,
-        metrics,
-        new int[] {1},
-        1,
-        Collections.singletonList(1L),
-        ByteBuffer.wrap(new byte[] {0}));
+    return FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+        .ofEqualityDeletes(1)
+        .withPath(UUID.randomUUID() + ".parquet")
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
   }
 
   private EventTestUtil() {}

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
@@ -18,6 +18,8 @@
  */
 package io.tabular.iceberg.connect.channel;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
@@ -25,13 +27,15 @@ import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.TableSinkConfig;
-import org.apache.iceberg.AppendFiles;
-import org.apache.iceberg.RowDelta;
-import org.apache.iceberg.Snapshot;
+import java.io.IOException;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
@@ -43,44 +47,53 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 public class ChannelTestBase {
   protected static final String SRC_TOPIC_NAME = "src-topic";
   protected static final String CTL_TOPIC_NAME = "ctl-topic";
-
-  protected Catalog catalog;
+  protected static final String CONTROL_CONSUMER_GROUP_ID = "cg-connector";
+  protected InMemoryCatalog catalog;
   protected Table table;
-  protected AppendFiles appendOp;
-  protected RowDelta deltaOp;
   protected IcebergSinkConfig config;
   protected KafkaClientFactory clientFactory;
   protected MockProducer<String, byte[]> producer;
   protected MockConsumer<String, byte[]> consumer;
   protected Admin admin;
 
+  private InMemoryCatalog initInMemoryCatalog() {
+    InMemoryCatalog inMemoryCatalog = new InMemoryCatalog();
+    inMemoryCatalog.initialize(null, ImmutableMap.of());
+    return inMemoryCatalog;
+  }
+
+  protected static final Namespace NAMESPACE = Namespace.of("db");
+  protected static final String TABLE_NAME = "tbl";
+  protected static final TableIdentifier TABLE_IDENTIFIER =
+      TableIdentifier.of(NAMESPACE, TABLE_NAME);
+  protected static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(2, "data", Types.StringType.get()),
+          required(3, "date", Types.StringType.get()));
+
+  protected static final String COMMIT_ID_SNAPSHOT_PROP = "kafka.connect.commit-id";
+  protected static final String OFFSETS_SNAPSHOT_PROP =
+      String.format("kafka.connect.offsets.%s.%s", CTL_TOPIC_NAME, CONTROL_CONSUMER_GROUP_ID);
+  protected static final String VTTS_SNAPSHOT_PROP = "kafka.connect.vtts";
+
   @BeforeEach
   @SuppressWarnings("deprecation")
   public void before() {
-    Snapshot snapshot = mock(Snapshot.class);
-    when(snapshot.snapshotId()).thenReturn(1L);
-
-    appendOp = mock(AppendFiles.class);
-    deltaOp = mock(RowDelta.class);
-
-    table = mock(Table.class);
-    when(table.currentSnapshot()).thenReturn(snapshot);
-    when(table.newAppend()).thenReturn(appendOp);
-    when(table.newRowDelta()).thenReturn(deltaOp);
-
-    catalog = mock(Catalog.class);
-    when(catalog.loadTable(any())).thenReturn(table);
+    catalog = initInMemoryCatalog();
+    catalog.createNamespace(NAMESPACE);
+    table = catalog.createTable(TABLE_IDENTIFIER, SCHEMA);
 
     config = mock(IcebergSinkConfig.class);
     when(config.controlTopic()).thenReturn(CTL_TOPIC_NAME);
-    when(config.controlGroupId()).thenReturn("group");
     when(config.commitThreads()).thenReturn(1);
-    when(config.controlGroupId()).thenReturn("cg-connector");
+    when(config.controlGroupId()).thenReturn(CONTROL_CONSUMER_GROUP_ID);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
 
     TopicPartitionInfo partitionInfo = mock(TopicPartitionInfo.class);
@@ -103,6 +116,11 @@ public class ChannelTestBase {
     when(clientFactory.createProducer(any())).thenReturn(producer);
     when(clientFactory.createConsumer(any())).thenReturn(consumer);
     when(clientFactory.createAdmin()).thenReturn(admin);
+  }
+
+  @AfterEach
+  public void after() throws IOException {
+    catalog.close();
   }
 
   protected void initConsumer() {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -62,7 +62,6 @@ public class WorkerTest extends ChannelTestBase {
   public void testDynamicRoute() {
     when(config.dynamicTablesEnabled()).thenReturn(true);
     when(config.tablesRouteField()).thenReturn(FIELD_NAME);
-    when(catalog.tableExists(any())).thenReturn(true);
     Map<String, Object> value = ImmutableMap.of(FIELD_NAME, TABLE_NAME);
     workerTest(value);
   }


### PR DESCRIPTION
Refactoring `ChannelTestBase` to use "real" catalog and table implementations rather than mocks. 
In my [next PR](https://github.com/tabular-io/iceberg-kafka-connect/pull/202), I have to use iceberg's transaction functionality and mocking out that functionality didn't seem worth it. 