### PR TITLE
DRAFT: (do not merge) zombie fencing improvement

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -390,16 +390,6 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getString(CONTROL_TOPIC_PROP);
   }
 
-  public String controlGroupId() {
-    String result = getString(CONTROL_GROUP_ID_PROP);
-    if (result != null) {
-      return result;
-    }
-    String connectorName = connectorName();
-    Preconditions.checkNotNull(connectorName, "Connector name cannot be null");
-    return DEFAULT_CONTROL_GROUP_PREFIX + connectorName;
-  }
-
   public String connectGroupId() {
     String result = getString(CONNECT_GROUP_ID_PROP);
     if (result != null) {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkTask.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkTask.java
@@ -89,7 +89,7 @@ public class IcebergSinkTask extends SinkTask {
       Collection<MemberDescription> members = groupDesc.members();
       if (isLeader(members, partitions)) {
         LOG.info("Task elected leader, starting commit coordinator");
-        Coordinator coordinator = new Coordinator(catalog, config, members, clientFactory);
+        Coordinator coordinator = new Coordinator(catalog, config, members, clientFactory, context);
         coordinatorThread = new CoordinatorThread(coordinator);
         coordinatorThread.start();
       }
@@ -98,7 +98,6 @@ public class IcebergSinkTask extends SinkTask {
     LOG.info("Starting commit worker");
     IcebergWriterFactory writerFactory = new IcebergWriterFactory(catalog, config);
     worker = new Worker(config, clientFactory, writerFactory, context);
-    worker.syncCommitOffsets();
     worker.start();
   }
 
@@ -169,10 +168,8 @@ public class IcebergSinkTask extends SinkTask {
   @Override
   public Map<TopicPartition, OffsetAndMetadata> preCommit(
       Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
-    if (worker == null) {
-      return ImmutableMap.of();
-    }
-    return worker.commitOffsets();
+    // offset commit is handled by the worker
+    return ImmutableMap.of();
   }
 
   @Override

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.BeforeEach;
 public class ChannelTestBase {
   protected static final String SRC_TOPIC_NAME = "src-topic";
   protected static final String CTL_TOPIC_NAME = "ctl-topic";
-  protected static final String CONTROL_CONSUMER_GROUP_ID = "cg-connector";
+  protected static final String CONNECT_CONSUMER_GROUP_ID = "cg-connect";
   protected InMemoryCatalog catalog;
   protected Table table;
   protected IcebergSinkConfig config;
@@ -80,7 +80,7 @@ public class ChannelTestBase {
 
   protected static final String COMMIT_ID_SNAPSHOT_PROP = "kafka.connect.commit-id";
   protected static final String OFFSETS_SNAPSHOT_PROP =
-      String.format("kafka.connect.offsets.%s.%s", CTL_TOPIC_NAME, CONTROL_CONSUMER_GROUP_ID);
+      String.format("kafka.connect.offsets.%s.%s", CTL_TOPIC_NAME, CONNECT_CONSUMER_GROUP_ID);
   protected static final String VTTS_SNAPSHOT_PROP = "kafka.connect.vtts";
 
   @BeforeEach
@@ -93,7 +93,7 @@ public class ChannelTestBase {
     config = mock(IcebergSinkConfig.class);
     when(config.controlTopic()).thenReturn(CTL_TOPIC_NAME);
     when(config.commitThreads()).thenReturn(1);
-    when(config.controlGroupId()).thenReturn(CONTROL_CONSUMER_GROUP_ID);
+    when(config.connectGroupId()).thenReturn(CONNECT_CONSUMER_GROUP_ID);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
 
     TopicPartitionInfo partitionInfo = mock(TopicPartitionInfo.class);

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -19,6 +19,7 @@
 package io.tabular.iceberg.connect.channel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.events.CommitCompletePayload;
@@ -44,6 +45,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -161,7 +163,9 @@ public class CoordinatorTest extends ChannelTestBase {
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
 
-    Coordinator coordinator = new Coordinator(catalog, config, ImmutableList.of(), clientFactory);
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
     coordinator.start();
 
     // init consumer after subscribe()
@@ -180,7 +184,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
     Event commitResponse =
         new Event(
-            config.controlGroupId(),
+            config.connectGroupId(),
             EventType.COMMIT_RESPONSE,
             new CommitResponsePayload(
                 StructType.of(),
@@ -193,7 +197,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
     Event commitReady =
         new Event(
-            config.controlGroupId(),
+            config.connectGroupId(),
             EventType.COMMIT_READY,
             new CommitReadyPayload(
                 commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts))));

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -95,7 +95,7 @@ public class WorkerTest extends ChannelTestBase {
     UUID commitId = UUID.randomUUID();
     Event commitRequest =
         new Event(
-            config.controlGroupId(), EventType.COMMIT_REQUEST, new CommitRequestPayload(commitId));
+            config.connectGroupId(), EventType.COMMIT_REQUEST, new CommitRequestPayload(commitId));
     byte[] bytes = Event.encode(commitRequest);
     consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
 


### PR DESCRIPTION
This PR passes in the consumer group metadata during offset commit for better zombie fencing. Because it makes use of the sink's internal Kafka consumer, we no longer need the separate consumer group used to manage offsets.

Don't merge this, this is meant to demonstrate a potential solution to improve zombie fencing. There are a few further items that can be cleaned up. Also it was only briefly tested. cc @fqaiser94 
