### PR TITLE
Deduplicate before committing and emit a log warning

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 
   testImplementation libs.mockito
   testImplementation libs.assertj
+
+  testImplementation 'ch.qos.logback:logback-classic:1.5.3'
 }
 
 configurations {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitState.java
@@ -49,14 +49,17 @@ public class CommitState {
     commitBuffer.add(envelope);
     if (!isCommitInProgress()) {
       LOG.warn(
-          "Received commit response when no commit in progress, this can happen during recovery");
+          "Received commit response with commit-id={} when no commit in progress, this can happen during recovery",
+          ((CommitResponsePayload) envelope.event().payload()).commitId());
     }
   }
 
   public void addReady(Envelope envelope) {
     readyBuffer.add((CommitReadyPayload) envelope.event().payload());
     if (!isCommitInProgress()) {
-      LOG.warn("Received commit ready when no commit in progress, this can happen during recovery");
+      LOG.warn(
+          "Received commit ready for commit-id={} when no commit in progress, this can happen during recovery",
+          ((CommitReadyPayload) envelope.event().payload()).commitId());
     }
   }
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -97,6 +97,7 @@ public class Coordinator extends Channel {
               EventType.COMMIT_REQUEST,
               new CommitRequestPayload(commitState.currentCommitId()));
       send(event);
+      LOG.info("Started new commit with commit-id={}", commitState.currentCommitId().toString());
     }
 
     consumeAvailable(POLL_DURATION);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -195,16 +195,16 @@ public class Coordinator extends Channel {
                 })
             .collect(toList());
 
-    Deduplicated deduplicated =
-        new Deduplicated(commitState.currentCommitId(), tableIdentifier, filteredEnvelopeList);
-
     List<DataFile> dataFiles =
-        deduplicated.dataFiles().stream()
+        Deduplicated.dataFiles(commitState.currentCommitId(), tableIdentifier, filteredEnvelopeList)
+            .stream()
             .filter(dataFile -> dataFile.recordCount() > 0)
             .collect(toList());
 
     List<DeleteFile> deleteFiles =
-        deduplicated.deleteFiles().stream()
+        Deduplicated.deleteFiles(
+                commitState.currentCommitId(), tableIdentifier, filteredEnvelopeList)
+            .stream()
             .filter(deleteFile -> deleteFile.recordCount() > 0)
             .collect(toList());
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Deduplicated.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Deduplicated.java
@@ -92,8 +92,8 @@ class Deduplicated {
   }
 
   /**
-   * Returns the deduplicated delete files from the batch of envelopes. Does not guarantee
-   * anything about the ordering of the files that are returned.
+   * Returns the deduplicated delete files from the batch of envelopes. Does not guarantee anything
+   * about the ordering of the files that are returned.
    */
   public List<DeleteFile> deleteFiles() {
     List<DeleteFile> dedupedInsidePayloads =

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Deduplicated.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Deduplicated.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.channel;
+
+import static java.util.stream.Collectors.toList;
+
+import io.tabular.iceberg.connect.events.CommitResponsePayload;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class Deduplicated {
+  private static final Logger LOG = LoggerFactory.getLogger(Deduplicated.class);
+  private final UUID currentCommitId;
+  private final TableIdentifier tableIdentifier;
+  private final List<Envelope> deduplicatedEnvelopes;
+
+  private static final String DATA_FILE_TYPE = "data";
+  private static final String DELETE_FILE_TYPE = "delete";
+
+  Deduplicated(UUID currentCommitId, TableIdentifier tableIdentifier, List<Envelope> batch) {
+    this.currentCommitId = currentCommitId;
+    this.tableIdentifier = tableIdentifier;
+    this.deduplicatedEnvelopes = deduplicateEnvelopes(ImmutableList.copyOf(batch));
+  }
+
+  /**
+   * Returns the deduplicated data files from the batch of envelopes. Does not guarantee anything
+   * about the ordering of the files that are returned.
+   */
+  public List<DataFile> dataFiles() {
+    List<DataFile> dedupedInsidePayloads =
+        deduplicatedEnvelopes.stream()
+            .flatMap(
+                envelope -> {
+                  CommitResponsePayload payload =
+                      (CommitResponsePayload) envelope.event().payload();
+                  List<DataFile> dataFiles = payload.dataFiles();
+                  if (dataFiles == null) {
+                    return Stream.empty();
+                  } else {
+                    return deduplicateFilesInPayload(
+                        dataFiles,
+                        Deduplicated::dataFilePath,
+                        DATA_FILE_TYPE,
+                        payload.commitId(),
+                        envelope.partition(),
+                        envelope.offset())
+                        .stream();
+                  }
+                })
+            .collect(toList());
+
+    List<DataFile> dedupedInsideAndAcrossPayloads =
+        deduplicateFiles(dedupedInsidePayloads, Deduplicated::dataFilePath, DATA_FILE_TYPE);
+
+    return ImmutableList.copyOf(dedupedInsideAndAcrossPayloads);
+  }
+
+  /**
+   * Returns the deduplicated delete files from the batch of envelopes. Does not guarantee
+   * anything about the ordering of the files that are returned.
+   */
+  public List<DeleteFile> deleteFiles() {
+    List<DeleteFile> dedupedInsidePayloads =
+        deduplicatedEnvelopes.stream()
+            .flatMap(
+                envelope -> {
+                  CommitResponsePayload payload =
+                      (CommitResponsePayload) envelope.event().payload();
+                  List<DeleteFile> deleteFiles = payload.deleteFiles();
+                  if (deleteFiles == null) {
+                    return Stream.empty();
+                  } else {
+                    return deduplicateFilesInPayload(
+                        deleteFiles,
+                        Deduplicated::deleteFilePath,
+                        DELETE_FILE_TYPE,
+                        payload.commitId(),
+                        envelope.partition(),
+                        envelope.offset())
+                        .stream();
+                  }
+                })
+            .collect(toList());
+
+    List<DeleteFile> dedupedInsideAndAcrossPayloads =
+        deduplicateFiles(dedupedInsidePayloads, Deduplicated::deleteFilePath, DELETE_FILE_TYPE);
+
+    return ImmutableList.copyOf(dedupedInsideAndAcrossPayloads);
+  }
+
+  private static class PartitionOffset {
+
+    private final int partition;
+    private final long offset;
+
+    PartitionOffset(int partition, long offset) {
+      this.partition = partition;
+      this.offset = offset;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      PartitionOffset that = (PartitionOffset) o;
+      return partition == that.partition && offset == that.offset;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(partition, offset);
+    }
+
+    @Override
+    public String toString() {
+      return "PartitionOffset{" + "partition=" + partition + ", offset=" + offset + '}';
+    }
+  }
+
+  private List<Envelope> deduplicateEnvelopes(List<Envelope> envelopes) {
+    return deduplicate(
+        envelopes,
+        envelope -> new PartitionOffset(envelope.partition(), envelope.offset()),
+        (numDuplicatedFiles, duplicatedPartitionOffset) ->
+            String.format(
+                "Detected %d envelopes with the same partition-offset=%d-%d during commitId=%s for table=%s",
+                numDuplicatedFiles,
+                duplicatedPartitionOffset.partition,
+                duplicatedPartitionOffset.offset,
+                currentCommitId.toString(),
+                tableIdentifier.toString()));
+  }
+
+  private static String dataFilePath(DataFile dataFile) {
+    return dataFile.path().toString();
+  }
+
+  private static String deleteFilePath(DeleteFile deleteFile) {
+    return deleteFile.path().toString();
+  }
+
+  private <T> List<T> deduplicateFilesInPayload(
+      List<T> files,
+      Function<T, String> getPathFn,
+      String fileType,
+      UUID payloadCommitId,
+      int partition,
+      long offset) {
+    return deduplicate(
+        files,
+        getPathFn,
+        (numDuplicatedFiles, duplicatedPath) ->
+            String.format(
+                "Detected %d %s files with the same path=%s in payload with payload-commit-id=%s for table=%s at partition=%s and offset=%s",
+                numDuplicatedFiles,
+                fileType,
+                duplicatedPath,
+                payloadCommitId.toString(),
+                tableIdentifier.toString(),
+                partition,
+                offset));
+  }
+
+  private <T> List<T> deduplicateFiles(
+      List<T> files, Function<T, String> getPathFn, String fileType) {
+    return deduplicate(
+        files,
+        getPathFn,
+        (numDuplicatedFiles, duplicatedPath) ->
+            String.format(
+                "Detected %d %s files with the same path=%s across payloads during commitId=%s for table=%s",
+                numDuplicatedFiles,
+                fileType,
+                duplicatedPath,
+                currentCommitId.toString(),
+                tableIdentifier.toString()));
+  }
+
+  private static <K, T> List<T> deduplicate(
+      List<T> files, Function<T, K> keyExtractor, BiFunction<Integer, K, String> logMessageFn) {
+    Map<K, List<T>> pathToFilesMapping = Maps.newHashMap();
+    files.forEach(
+        f ->
+            pathToFilesMapping
+                .computeIfAbsent(keyExtractor.apply(f), ignored -> Lists.newArrayList())
+                .add(f));
+
+    return pathToFilesMapping.entrySet().stream()
+        .flatMap(
+            entry -> {
+              K maybeDuplicatedKey = entry.getKey();
+              List<T> maybeDuplicatedFiles = entry.getValue();
+              int numDuplicatedFiles = maybeDuplicatedFiles.size();
+              if (numDuplicatedFiles > 1) {
+                LOG.warn(logMessageFn.apply(numDuplicatedFiles, maybeDuplicatedKey));
+              }
+              return Stream.of(maybeDuplicatedFiles.get(0));
+            })
+        .collect(toList());
+  }
+}

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
@@ -49,7 +49,6 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.slf4j.LoggerFactory;
 
 public class ChannelTestBase {
   protected static final String SRC_TOPIC_NAME = "src-topic";
@@ -62,7 +61,6 @@ public class ChannelTestBase {
   protected MockProducer<String, byte[]> producer;
   protected MockConsumer<String, byte[]> consumer;
   protected Admin admin;
-  protected MemoryAppender deduplicatedMemoryAppender;
 
   private InMemoryCatalog initInMemoryCatalog() {
     InMemoryCatalog inMemoryCatalog = new InMemoryCatalog();
@@ -118,17 +116,11 @@ public class ChannelTestBase {
     when(clientFactory.createProducer(any())).thenReturn(producer);
     when(clientFactory.createConsumer(any())).thenReturn(consumer);
     when(clientFactory.createAdmin()).thenReturn(admin);
-
-    deduplicatedMemoryAppender = new MemoryAppender();
-    ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Deduplicated.class))
-        .addAppender(deduplicatedMemoryAppender);
-    deduplicatedMemoryAppender.start();
   }
 
   @AfterEach
   public void after() throws IOException {
     catalog.close();
-    deduplicatedMemoryAppender.stop();
   }
 
   protected void initConsumer() {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
@@ -49,6 +49,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.LoggerFactory;
 
 public class ChannelTestBase {
   protected static final String SRC_TOPIC_NAME = "src-topic";
@@ -61,6 +62,7 @@ public class ChannelTestBase {
   protected MockProducer<String, byte[]> producer;
   protected MockConsumer<String, byte[]> consumer;
   protected Admin admin;
+  protected MemoryAppender memoryAppender;
 
   private InMemoryCatalog initInMemoryCatalog() {
     InMemoryCatalog inMemoryCatalog = new InMemoryCatalog();
@@ -116,11 +118,17 @@ public class ChannelTestBase {
     when(clientFactory.createProducer(any())).thenReturn(producer);
     when(clientFactory.createConsumer(any())).thenReturn(consumer);
     when(clientFactory.createAdmin()).thenReturn(admin);
+
+    memoryAppender = new MemoryAppender();
+    ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Coordinator.class))
+        .addAppender(memoryAppender);
+    memoryAppender.start();
   }
 
   @AfterEach
   public void after() throws IOException {
     catalog.close();
+    memoryAppender.stop();
   }
 
   protected void initConsumer() {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
@@ -62,7 +62,7 @@ public class ChannelTestBase {
   protected MockProducer<String, byte[]> producer;
   protected MockConsumer<String, byte[]> consumer;
   protected Admin admin;
-  protected MemoryAppender memoryAppender;
+  protected MemoryAppender deduplicatedMemoryAppender;
 
   private InMemoryCatalog initInMemoryCatalog() {
     InMemoryCatalog inMemoryCatalog = new InMemoryCatalog();
@@ -119,16 +119,16 @@ public class ChannelTestBase {
     when(clientFactory.createConsumer(any())).thenReturn(consumer);
     when(clientFactory.createAdmin()).thenReturn(admin);
 
-    memoryAppender = new MemoryAppender();
-    ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Coordinator.class))
-        .addAppender(memoryAppender);
-    memoryAppender.start();
+    deduplicatedMemoryAppender = new MemoryAppender();
+    ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Deduplicated.class))
+        .addAppender(deduplicatedMemoryAppender);
+    deduplicatedMemoryAppender.start();
   }
 
   @AfterEach
   public void after() throws IOException {
     catalog.close();
-    memoryAppender.stop();
+    deduplicatedMemoryAppender.stop();
   }
 
   protected void initConsumer() {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -76,7 +76,7 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals("{\"0\":3}", summary.get(OFFSETS_SNAPSHOT_PROP));
     Assertions.assertEquals(Long.toString(ts), summary.get(VTTS_SNAPSHOT_PROP));
 
-    assertThat(memoryAppender.getWarnOrHigher())
+    assertThat(deduplicatedMemoryAppender.getWarnOrHigher())
         .as("Expected no warn or higher log messages")
         .hasSize(0);
   }
@@ -107,7 +107,7 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals("{\"0\":3}", summary.get(OFFSETS_SNAPSHOT_PROP));
     Assertions.assertEquals(Long.toString(ts), summary.get(VTTS_SNAPSHOT_PROP));
 
-    assertThat(memoryAppender.getWarnOrHigher())
+    assertThat(deduplicatedMemoryAppender.getWarnOrHigher())
         .as("Expected no warn or higher log messages")
         .hasSize(0);
   }
@@ -123,7 +123,7 @@ public class CoordinatorTest extends ChannelTestBase {
     List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
     Assertions.assertEquals(0, snapshots.size());
 
-    assertThat(memoryAppender.getWarnOrHigher())
+    assertThat(deduplicatedMemoryAppender.getWarnOrHigher())
         .as("Expected no warn or higher log messages")
         .hasSize(0);
   }
@@ -149,11 +149,8 @@ public class CoordinatorTest extends ChannelTestBase {
     List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
     Assertions.assertEquals(0, snapshots.size());
 
-    List<String> warnOrHigherLogMessages = memoryAppender.getWarnOrHigher();
-    assertThat(warnOrHigherLogMessages).as("Expected 1 log message").hasSize(1);
-    assertThat(warnOrHigherLogMessages.get(0))
-        .as("Expected commit failed message warning")
-        .isEqualTo("Commit failed, will try again next cycle");
+    List<String> warnOrHigherLogMessages = deduplicatedMemoryAppender.getWarnOrHigher();
+    assertThat(warnOrHigherLogMessages).as("Expected 0 log messages").hasSize(0);
   }
 
   @Test
@@ -197,7 +194,7 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(1, ImmutableList.copyOf(snapshot.addedDataFiles(table.io())).size());
     Assertions.assertEquals(0, ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io())).size());
 
-    List<String> warnOrHigherLogMessages = memoryAppender.getWarnOrHigher();
+    List<String> warnOrHigherLogMessages = deduplicatedMemoryAppender.getWarnOrHigher();
     assertThat(warnOrHigherLogMessages).as("Expected 1 log message").hasSize(1);
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
@@ -246,7 +243,7 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(0, ImmutableList.copyOf(snapshot.addedDataFiles(table.io())).size());
     Assertions.assertEquals(1, ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io())).size());
 
-    List<String> warnOrHigherLogMessages = memoryAppender.getWarnOrHigher();
+    List<String> warnOrHigherLogMessages = deduplicatedMemoryAppender.getWarnOrHigher();
     assertThat(warnOrHigherLogMessages).as("Expected 1 log message").hasSize(1);
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
@@ -290,12 +287,12 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(1, ImmutableList.copyOf(snapshot.addedDataFiles(table.io())).size());
     Assertions.assertEquals(0, ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io())).size());
 
-    List<String> warnOrHigherLogMessages = memoryAppender.getWarnOrHigher();
+    List<String> warnOrHigherLogMessages = deduplicatedMemoryAppender.getWarnOrHigher();
     assertThat(warnOrHigherLogMessages).as("Expected 1 log message").hasSize(1);
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 data files with the same path=.*\\.parquet in payload with commitId=.* for table=db\\.tbl at partition=0 and offset=1");
+            "Detected 2 data files with the same path=.*\\.parquet in payload with payload-commit-id=.* for table=db\\.tbl at partition=0 and offset=1");
   }
 
   @Test
@@ -334,12 +331,12 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(0, ImmutableList.copyOf(snapshot.addedDataFiles(table.io())).size());
     Assertions.assertEquals(1, ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io())).size());
 
-    List<String> warnOrHigherLogMessages = memoryAppender.getWarnOrHigher();
+    List<String> warnOrHigherLogMessages = deduplicatedMemoryAppender.getWarnOrHigher();
     assertThat(warnOrHigherLogMessages).as("Expected 1 log message").hasSize(1);
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 delete files with the same path=.*\\.parquet in payload with commitId=.* for table=db\\.tbl at partition=0 and offset=1");
+            "Detected 2 delete files with the same path=.*\\.parquet in payload with payload-commit-id=.* for table=db\\.tbl at partition=0 and offset=1");
   }
 
   private void assertCommitTable(int idx, UUID commitId, long ts) {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -295,7 +295,7 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 data files with the same path=.*\\.parquet in payload with commitId=.* for table=db\\.tbl");
+            "Detected 2 data files with the same path=.*\\.parquet in payload with commitId=.* for table=db\\.tbl at partition=0 and offset=1");
   }
 
   @Test
@@ -339,7 +339,7 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 delete files with the same path=.*\\.parquet in payload with commitId=.* for table=db\\.tbl");
+            "Detected 2 delete files with the same path=.*\\.parquet in payload with commitId=.* for table=db\\.tbl at partition=0 and offset=1");
   }
 
   private void assertCommitTable(int idx, UUID commitId, long ts) {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -292,7 +292,7 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 data files with the same path=.*\\.parquet in payload with payload-commit-id=.* for table=db\\.tbl at partition=0 and offset=1");
+            "Detected 2 data files with the same path=.*\\.parquet in payload with payload-commit-id=.* for table=db\\.tbl at partition=0 and offset=1 with event-id=.* and group-id=.* and event-type=.* and event-timestamp=.*");
   }
 
   @Test
@@ -336,7 +336,7 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 delete files with the same path=.*\\.parquet in payload with payload-commit-id=.* for table=db\\.tbl at partition=0 and offset=1");
+            "Detected 2 delete files with the same path=.*\\.parquet in payload with payload-commit-id=.* for table=db\\.tbl at partition=0 and offset=1 with event-id=.* and group-id=.* and event-type=.* and event-timestamp=.*");
   }
 
   private void assertCommitTable(int idx, UUID commitId, long ts) {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -199,7 +199,7 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 data files with the same path=.*\\.parquet across payloads during commitId=.* for table=db\\.tbl");
+            "Detected 2 data files with the same path=.*\\.parquet for table=.* during commit-id=.* in the following \\(deduplicated\\) events=\\[Envelope\\(.*\\), Envelope\\(.*\\)\\]$");
   }
 
   @Test
@@ -248,7 +248,7 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 delete files with the same path=.*\\.parquet across payloads during commitId=.* for table=db\\.tbl");
+            "Detected 2 delete files with the same path=.*\\.parquet for table=.* during commit-id=.* in the following \\(deduplicated\\) events=\\[Envelope\\(.*\\), Envelope\\(.*\\)\\]$");
   }
 
   @Test
@@ -292,7 +292,7 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 data files with the same path=.*\\.parquet in payload with payload-commit-id=.* for table=db\\.tbl at partition=0 and offset=1 with event-id=.* and group-id=.* and event-type=.* and event-timestamp=.*");
+            "Detected 2 data files with the same path=.*\\.parquet in the same event=Envelope\\(.*\\) for table=.* during commit-id=.*$");
   }
 
   @Test
@@ -336,7 +336,7 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(warnOrHigherLogMessages.get(0))
         .as("Expected duplicates detected message warning")
         .matches(
-            "Detected 2 delete files with the same path=.*\\.parquet in payload with payload-commit-id=.* for table=db\\.tbl at partition=0 and offset=1 with event-id=.* and group-id=.* and event-type=.* and event-timestamp=.*");
+            "Detected 2 delete files with the same path=.*\\.parquet in the same event=Envelope\\(.*\\) for table=.* during commit-id=.*$");
   }
 
   private void assertCommitTable(int idx, UUID commitId, long ts) {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/DeduplicatedTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/DeduplicatedTest.java
@@ -159,6 +159,17 @@ class DeduplicatedTest {
   }
 
   @Test
+  public void testNullFilesShouldReturnEmptyFiles() {
+    Event event = commitResponseEvent(null, null);
+    Envelope envelope = new Envelope(event, 0, 100);
+
+    List<Envelope> batch = ImmutableList.of(envelope);
+
+    assertExpectedFiles(batch, ImmutableSet.of(), ImmutableSet.of());
+    assertNoWarnOrHigherLogs();
+  }
+
+  @Test
   public void testShouldReturnEmptyFiles() {
     Event event = commitResponseEvent(ImmutableList.of(), ImmutableList.of());
     Envelope envelope = new Envelope(event, 0, 100);

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/DeduplicatedTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/DeduplicatedTest.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.tabular.iceberg.connect.events.CommitResponsePayload;
+import io.tabular.iceberg.connect.events.Event;
+import io.tabular.iceberg.connect.events.EventType;
+import io.tabular.iceberg.connect.events.TableName;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+class DeduplicatedTest {
+
+  protected MemoryAppender deduplicatedMemoryAppender;
+
+  private static final UUID CURRENT_COMMIT_ID =
+      UUID.fromString("cf602430-0f4d-41d8-a3e9-171848d89832");
+  private static final UUID PAYLOAD_COMMIT_ID =
+      UUID.fromString("4142add7-7c92-4bbe-b864-21ce8ac4bf53");
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of("db", "tbl");
+  private static final TableName TABLE_NAME = TableName.of(TABLE_IDENTIFIER);
+  private static final String CONTROL_GROUP_ID = "cg-connector";
+  private static final DataFile DATA_FILE_1 = createDataFile("1");
+  private static final DataFile DATA_FILE_2 = createDataFile("2");
+  private static final DeleteFile DELETE_FILE_1 = createDeleteFile("1");
+  private static final DeleteFile DELETE_FILE_2 = createDeleteFile("2");
+
+  @BeforeEach
+  public void before() {
+    deduplicatedMemoryAppender = new MemoryAppender();
+    ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Deduplicated.class))
+        .addAppender(deduplicatedMemoryAppender);
+    deduplicatedMemoryAppender.start();
+  }
+
+  @AfterEach
+  public void after() {
+    deduplicatedMemoryAppender.stop();
+  }
+
+  public static DataFile createDataFile(String fileSuffix) {
+    return DataFiles.builder(PartitionSpec.unpartitioned())
+        .withPath("data-" + fileSuffix + ".parquet")
+        .withFormat(FileFormat.PARQUET)
+        .withFileSizeInBytes(100L)
+        .withRecordCount(5)
+        .build();
+  }
+
+  public static DeleteFile createDeleteFile(String fileSuffix) {
+    return FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+        .ofEqualityDeletes(1)
+        .withPath("delete-" + fileSuffix + ".parquet")
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private void assertExpectedFiles(
+      Deduplicated deduplicated,
+      Set<DataFile> expectedDatafiles,
+      Set<DeleteFile> expectedDeleteFiles) {
+    Assertions.assertEquals(expectedDatafiles, Sets.newHashSet(deduplicated.dataFiles()));
+    Assertions.assertEquals(expectedDeleteFiles, Sets.newHashSet(deduplicated.deleteFiles()));
+  }
+
+  private void assertNoWarnOrHigherLogs() {
+    assertThat(deduplicatedMemoryAppender.getWarnOrHigher())
+        .as("Expected 0 log messages")
+        .hasSize(0);
+  }
+
+  private void assertWarnOrHigherLogsContains(String... expectedMessages) {
+    assertThat(deduplicatedMemoryAppender.getWarnOrHigher())
+        .containsExactlyInAnyOrder(expectedMessages);
+  }
+
+  private Event commitResponseEvent(List<DataFile> dataFiles, List<DeleteFile> deleteFiles) {
+    return new Event(
+        CONTROL_GROUP_ID,
+        EventType.COMMIT_RESPONSE,
+        new CommitResponsePayload(
+            Types.StructType.of(), PAYLOAD_COMMIT_ID, TABLE_NAME, dataFiles, deleteFiles));
+  }
+
+  @Test
+  public void testShouldReturnEmptyFiles() {
+    Event event = commitResponseEvent(ImmutableList.of(), ImmutableList.of());
+    Envelope envelope = new Envelope(event, 0, 100);
+
+    List<Envelope> batch = ImmutableList.of(envelope);
+
+    Deduplicated deduplicated = new Deduplicated(CURRENT_COMMIT_ID, TABLE_IDENTIFIER, batch);
+
+    assertExpectedFiles(deduplicated, ImmutableSet.of(), ImmutableSet.of());
+    assertNoWarnOrHigherLogs();
+  }
+
+  @Test
+  public void testShouldReturnNonDuplicatedFile() {
+    Event event =
+        commitResponseEvent(ImmutableList.of(DATA_FILE_1), ImmutableList.of(DELETE_FILE_1));
+    Envelope envelope = new Envelope(event, 0, 100);
+
+    List<Envelope> batch = ImmutableList.of(envelope);
+
+    Deduplicated deduplicated = new Deduplicated(CURRENT_COMMIT_ID, TABLE_IDENTIFIER, batch);
+
+    assertExpectedFiles(deduplicated, ImmutableSet.of(DATA_FILE_1), ImmutableSet.of(DELETE_FILE_1));
+    assertNoWarnOrHigherLogs();
+  }
+
+  @Test
+  public void testShouldReturnNonDuplicatedFiles() {
+    Event event =
+        commitResponseEvent(
+            ImmutableList.of(DATA_FILE_1, DATA_FILE_2),
+            ImmutableList.of(DELETE_FILE_1, DELETE_FILE_2));
+    Envelope envelope = new Envelope(event, 0, 100);
+
+    List<Envelope> batch = ImmutableList.of(envelope);
+
+    Deduplicated deduplicated = new Deduplicated(CURRENT_COMMIT_ID, TABLE_IDENTIFIER, batch);
+
+    assertExpectedFiles(
+        deduplicated,
+        ImmutableSet.of(DATA_FILE_1, DATA_FILE_2),
+        ImmutableSet.of(DELETE_FILE_1, DELETE_FILE_2));
+    assertNoWarnOrHigherLogs();
+  }
+
+  @Test
+  public void testShouldReturnNonDuplicatedFilesFromMultipleEvents() {
+    Event event1 =
+        commitResponseEvent(ImmutableList.of(DATA_FILE_1), ImmutableList.of(DELETE_FILE_1));
+    Event event2 =
+        commitResponseEvent(ImmutableList.of(DATA_FILE_2), ImmutableList.of(DELETE_FILE_2));
+
+    List<Envelope> batch =
+        ImmutableList.of(new Envelope(event1, 0, 100), new Envelope(event2, 0, 101));
+
+    Deduplicated deduplicated = new Deduplicated(CURRENT_COMMIT_ID, TABLE_IDENTIFIER, batch);
+
+    assertExpectedFiles(
+        deduplicated,
+        ImmutableSet.of(DATA_FILE_1, DATA_FILE_2),
+        ImmutableSet.of(DELETE_FILE_1, DELETE_FILE_2));
+    assertNoWarnOrHigherLogs();
+  }
+
+  @Test
+  public void testShouldDeduplicateEnvelopes() {
+    Event event =
+        commitResponseEvent(
+            ImmutableList.of(DATA_FILE_1, DATA_FILE_2),
+            ImmutableList.of(DELETE_FILE_1, DELETE_FILE_2));
+    Envelope duplicatedEnvelope = new Envelope(event, 0, 100);
+
+    List<Envelope> batch = ImmutableList.of(duplicatedEnvelope, duplicatedEnvelope);
+
+    Deduplicated deduplicated = new Deduplicated(CURRENT_COMMIT_ID, TABLE_IDENTIFIER, batch);
+
+    assertExpectedFiles(
+        deduplicated,
+        ImmutableSet.of(DATA_FILE_1, DATA_FILE_2),
+        ImmutableSet.of(DELETE_FILE_1, DELETE_FILE_2));
+
+    assertWarnOrHigherLogsContains(
+        String.format(
+            "Detected 2 envelopes with the same partition-offset=0-100 during commitId=%s for table=%s",
+            CURRENT_COMMIT_ID, TABLE_IDENTIFIER));
+  }
+
+  @Test
+  public void testShouldDeduplicateFilesInsidePayloads() {
+    Event event =
+        commitResponseEvent(
+            ImmutableList.of(DATA_FILE_1, DATA_FILE_2, DATA_FILE_1),
+            ImmutableList.of(DELETE_FILE_1, DELETE_FILE_2, DELETE_FILE_1));
+    Envelope envelope = new Envelope(event, 0, 100);
+
+    List<Envelope> batch = ImmutableList.of(envelope);
+
+    Deduplicated deduplicated = new Deduplicated(CURRENT_COMMIT_ID, TABLE_IDENTIFIER, batch);
+
+    assertExpectedFiles(
+        deduplicated,
+        ImmutableSet.of(DATA_FILE_1, DATA_FILE_2),
+        ImmutableSet.of(DELETE_FILE_1, DELETE_FILE_2));
+
+    assertWarnOrHigherLogsContains(
+        String.format(
+            "Detected 2 data files with the same path=data-1.parquet in payload with payload-commit-id=%s for table=%s at partition=0 and offset=100",
+            PAYLOAD_COMMIT_ID, TABLE_IDENTIFIER),
+        String.format(
+            "Detected 2 delete files with the same path=delete-1.parquet in payload with payload-commit-id=%s for table=%s at partition=0 and offset=100",
+            PAYLOAD_COMMIT_ID, TABLE_IDENTIFIER));
+  }
+
+  @Test
+  public void testShouldDeduplicateFilesAcrossPayloads() {
+    Event event1 =
+        commitResponseEvent(ImmutableList.of(DATA_FILE_1), ImmutableList.of(DELETE_FILE_1));
+    Event event2 =
+        commitResponseEvent(
+            ImmutableList.of(DATA_FILE_1, DATA_FILE_2),
+            ImmutableList.of(DELETE_FILE_1, DELETE_FILE_2));
+
+    List<Envelope> batch =
+        ImmutableList.of(new Envelope(event1, 0, 100), new Envelope(event2, 0, 101));
+
+    Deduplicated deduplicated = new Deduplicated(CURRENT_COMMIT_ID, TABLE_IDENTIFIER, batch);
+
+    assertExpectedFiles(
+        deduplicated,
+        ImmutableSet.of(DATA_FILE_1, DATA_FILE_2),
+        ImmutableSet.of(DELETE_FILE_1, DELETE_FILE_2));
+
+    assertWarnOrHigherLogsContains(
+        String.format(
+            "Detected 2 data files with the same path=data-1.parquet across payloads during commitId=%s for table=%s",
+            CURRENT_COMMIT_ID, TABLE_IDENTIFIER),
+        String.format(
+            "Detected 2 delete files with the same path=delete-1.parquet across payloads during commitId=%s for table=%s",
+            CURRENT_COMMIT_ID, TABLE_IDENTIFIER));
+  }
+
+  @Test
+  public void testShouldHandleComplexCase() {
+    Event event1 =
+        commitResponseEvent(ImmutableList.of(DATA_FILE_1), ImmutableList.of(DELETE_FILE_1));
+    Event event2 =
+        commitResponseEvent(
+            ImmutableList.of(DATA_FILE_1, DATA_FILE_2),
+            ImmutableList.of(DELETE_FILE_1, DELETE_FILE_2));
+    Event event3 =
+        commitResponseEvent(
+            ImmutableList.of(DATA_FILE_1, DATA_FILE_2, DATA_FILE_2),
+            ImmutableList.of(DELETE_FILE_1, DELETE_FILE_2, DELETE_FILE_2));
+
+    List<Envelope> batch =
+        ImmutableList.of(
+            new Envelope(event1, 0, 100),
+            new Envelope(event2, 0, 101),
+            new Envelope(event1, 0, 100),
+            new Envelope(event3, 0, 102));
+
+    Deduplicated deduplicated = new Deduplicated(CURRENT_COMMIT_ID, TABLE_IDENTIFIER, batch);
+
+    assertExpectedFiles(
+        deduplicated,
+        ImmutableSet.of(DATA_FILE_1, DATA_FILE_2),
+        ImmutableSet.of(DELETE_FILE_1, DELETE_FILE_2));
+
+    assertWarnOrHigherLogsContains(
+        String.format(
+            "Detected 2 envelopes with the same partition-offset=0-100 during commitId=%s for table=%s",
+            CURRENT_COMMIT_ID, TABLE_IDENTIFIER),
+        String.format(
+            "Detected 2 data files with the same path=data-2.parquet in payload with payload-commit-id=%s for table=%s at partition=0 and offset=102",
+            PAYLOAD_COMMIT_ID, TABLE_IDENTIFIER),
+        String.format(
+            "Detected 2 data files with the same path=data-2.parquet across payloads during commitId=%s for table=%s",
+            CURRENT_COMMIT_ID, TABLE_IDENTIFIER),
+        String.format(
+            "Detected 3 data files with the same path=data-1.parquet across payloads during commitId=%s for table=%s",
+            CURRENT_COMMIT_ID, TABLE_IDENTIFIER),
+        String.format(
+            "Detected 2 delete files with the same path=delete-2.parquet in payload with payload-commit-id=%s for table=%s at partition=0 and offset=102",
+            PAYLOAD_COMMIT_ID, TABLE_IDENTIFIER),
+        String.format(
+            "Detected 2 delete files with the same path=delete-2.parquet across payloads during commitId=%s for table=%s",
+            CURRENT_COMMIT_ID, TABLE_IDENTIFIER),
+        String.format(
+            "Detected 3 delete files with the same path=delete-1.parquet across payloads during commitId=%s for table=%s",
+            CURRENT_COMMIT_ID, TABLE_IDENTIFIER));
+
+    // call a second time to make sure there are no mutability bugs
+    assertExpectedFiles(
+        deduplicated,
+        ImmutableSet.of(DATA_FILE_1, DATA_FILE_2),
+        ImmutableSet.of(DELETE_FILE_1, DELETE_FILE_2));
+  }
+}

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/MemoryAppender.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/MemoryAppender.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.channel;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+class MemoryAppender
+    extends ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> {
+  public List<ch.qos.logback.classic.spi.ILoggingEvent> getLoggedEvents() {
+    return ImmutableList.copyOf(this.list);
+  }
+
+  public List<String> getWarnOrHigher() {
+    return getLoggedEvents().stream()
+        .filter(e -> e.getLevel().isGreaterOrEqual(ch.qos.logback.classic.Level.WARN))
+        .map(e -> e.getMessage())
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
Deduplicates data and delete files, both within and across payloads received from kafka. 
We have reason to believe that in one instance in production a datafile was committed twice in the same append operation. 
This appears to be an extremely rare incident which is making it very difficult to determine the root cause of the bug. 
As a result, we're also adding some logging to help detect this quicker and with more contextual information. 