### PR TITLE
SMT for json parsing

### DIFF
--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -53,7 +53,7 @@ _(Experimental)_
 
 The `JsonToMapTransform` SMT parses Json object payloads.  It is intended for use when the incoming data is too 
 inconsistent for the `iceberg-connector` to infer `Struct` schemas from (e.g. the object keys are too variable 
-and this leads to an explosion of schema evoltions and columns).  This will get the data into Iceberg where it can 
+and this leads to an explosion of schema evolutions and columns).  This will get the data into Iceberg where it can 
 be further processed by query engines into a more manageable form.  
 
 It will parse string values into `SinkRecords` with a Schema and a Struct.  It assumes the messages are json objects 

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -51,16 +51,21 @@ It will promote the `before` or `after` element fields to top level and add the 
 # JsonToMapTransform
 _(Experimental)_ 
 
-The `JsonToMapTransform` SMT parses Json object payloads.  It is intended for use when the incoming data is too 
-inconsistent for the `iceberg-connector` to infer `Struct` schemas from (e.g. the object keys are too variable 
-and this leads to an explosion of schema evolutions and columns).  This will get the data into Iceberg where it can 
-be further processed by query engines into a more manageable form.  
+The `JsonToMapTransform` SMT parses Strings as Json object payloads to infer schemas.  The iceberg-kafka-connect 
+connector for schema-less data (e.g. the Map produced by the Kafka supplied JsonConverter) is to Maps as Iceberg 
+Structs.  This is fine when the JSON is well-structured, but when you have JSON objects with dynamically 
+changing keys, it will lead to an explosion of columns in the Iceberg table due to schema evolutions. 
 
-It will parse string values into `SinkRecords` with a Schema and a Struct.  It assumes the messages are json objects 
-themselves and will throw exceptions if the records are primitives.  You must use `StringConverter` as the 
-`ValueConverter`, not `org.apache.kafka.connect.json.JsonConverter`.
+This SMT is useful in situations where the JSON is not well-structured, in order to get data into Iceberg where 
+it can be further processed by query engines into a more manageable form.  It will convert nested objects to Maps of
+strings (rather than Struct). The connector will create Iceberg tables with Iceberg Map type columns for the JSON objects.
 
-Keys are not transformed. 
+Note:
+
+- The SMT accepts messages with String values as valid input.
+  - It expects JSON objects (`{...}`) in those strings. 
+- You must use the `stringConverter` as the `value.converter` setting for your connector, not `jsonConverter`
+- Message keys are not transformed by passed along as-is by the SMT
 
 ## Configuration
 

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -93,7 +93,7 @@ SinkRecord.schema:
   
 Sinkrecord.value (Struct): 
   "payload"  : Map(
-    "key" L "1",
+    "key" : "1",
     "array" : "[1,"two",3]"
     "empty_obj": "{}"
     "nested_obj": "{"some_key":["one","two"]}}"

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -64,12 +64,12 @@ themselves and will throw exceptions if the records are primitives.  You must us
 
 | Property             | Description  (default value)             |
 |----------------------|------------------------------------------|
-| transforms.json.root | (false) Boolean value to start at root   |
+| json.root | (false) Boolean value to start at root   |
 
-The `transform.json.root` is meant for the most inconsistent data.  It will construct a Struct with a single field 
+The `transforms.IDENTIFIER_HERE.json.root` is meant for the most inconsistent data.  It will construct a Struct with a single field 
 called `payload` with a Schema of `Map<String, String>`.  
 
-If `transform.json.root` is false (the default), it will construct a Struct with inferred schemas for primitive and
+If `transforms.IDENTIFIER_HERE.json.root` is false (the default), it will construct a Struct with inferred schemas for primitive and
 array fields.  Nested objects become fields of type `Map<String, String>`.
 
 Keys with empty arrays and empty objects are filtered out from the final schema.  Arrays will be typed unless the 

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -57,8 +57,10 @@ and this leads to an explosion of schema evolutions and columns).  This will get
 be further processed by query engines into a more manageable form.  
 
 It will parse string values into `SinkRecords` with a Schema and a Struct.  It assumes the messages are json objects 
-themselves and will throw exceptions if the records are primitives.  You must use `StringDeserializer` as the 
+themselves and will throw exceptions if the records are primitives.  You must use `StringConverter` as the 
 `ValueConverter`, not `org.apache.kafka.connect.json.JsonConverter`.
+
+Keys are not transformed. 
 
 ## Configuration
 

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -57,7 +57,8 @@ and this leads to an explosion of schema evolutions and columns).  This will get
 be further processed by query engines into a more manageable form.  
 
 It will parse string values into `SinkRecords` with a Schema and a Struct.  It assumes the messages are json objects 
-themselves and will throw exceptions if the records are primitives. 
+themselves and will throw exceptions if the records are primitives.  You must use `StringDeserializer` as the 
+`ValueConverter`, not `org.apache.kafka.connect.json.JsonConverter`.
 
 ## Configuration
 

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -52,20 +52,20 @@ It will promote the `before` or `after` element fields to top level and add the 
 _(Experimental)_ 
 
 The `JsonToMapTransform` SMT parses Strings as Json object payloads to infer schemas.  The iceberg-kafka-connect 
-connector for schema-less data (e.g. the Map produced by the Kafka supplied JsonConverter) is to Maps as Iceberg 
+connector for schema-less data (e.g. the Map produced by the Kafka supplied JsonConverter) is to convert Maps into Iceberg 
 Structs.  This is fine when the JSON is well-structured, but when you have JSON objects with dynamically 
 changing keys, it will lead to an explosion of columns in the Iceberg table due to schema evolutions. 
 
 This SMT is useful in situations where the JSON is not well-structured, in order to get data into Iceberg where 
-it can be further processed by query engines into a more manageable form.  It will convert nested objects to Maps of
-strings (rather than Struct). The connector will create Iceberg tables with Iceberg Map type columns for the JSON objects.
+it can be further processed by query engines into a more manageable form. It will convert nested objects to 
+Maps and include Map type in the Schema.  The connector will respect the Schema and create Iceberg tables with Iceberg
+Map (String) columns for the JSON objects. 
 
 Note:
 
-- The SMT accepts messages with String values as valid input.
-  - It expects JSON objects (`{...}`) in those strings. 
 - You must use the `stringConverter` as the `value.converter` setting for your connector, not `jsonConverter`
-- Message keys are not transformed by passed along as-is by the SMT
+  - It expects JSON objects (`{...}`) in those strings. 
+- Message keys, tombstones, and headers are not transformed and are passed along as-is by the SMT
 
 ## Configuration
 
@@ -93,7 +93,7 @@ Example json:
 }
 ```
 
-Will become the following if `transform.json.root` is true:
+Will become the following if `json.root` is true:
 
 ```
 SinkRecord.schema: 
@@ -108,7 +108,7 @@ Sinkrecord.value (Struct):
    )
 ```
 
-Will become the following if `transform.json.root` is false
+Will become the following if `json.root` is false
 
 ```
 SinkRecord.schema: 

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -91,8 +91,13 @@ Will become the following if `transform.json.root` is true:
 SinkRecord.schema: 
   "payload" : (Optional) Map<String, String>
   
-Sinkrecord.value: 
-  "payload" (Map<String, String>) : "{"key":1,"array":[1,"two",3],"empty_obj":{},"nested_obj":{"some_key":["one","two"]}}
+Sinkrecord.value (Struct): 
+  "payload"  : Map(
+    "key" L "1",
+    "array" : "[1,"two",3]"
+    "empty_obj": "{}"
+    "nested_obj": "{"some_key":["one","two"]}}"
+   )
 ```
 
 Will become the following if `transform.json.root` is false
@@ -103,7 +108,7 @@ SinkRecord.schema:
   "array": (Optional) Array<String>,
   "nested_object": (Optional) Map<string, String>
   
-SinkRecord.value:
+SinkRecord.value (Struct):
  "key" 1, 
  "array" ["1", "two", "3"] 
  "nested_object" Map ("some_key" : "["one", "two"]") 

--- a/kafka-connect-transforms/README.md
+++ b/kafka-connect-transforms/README.md
@@ -47,3 +47,64 @@ It will promote the `before` or `after` element fields to top level and add the 
 | Property            | Description                                                                       |
 |---------------------|-----------------------------------------------------------------------------------|
 | cdc.target.pattern  | Pattern to use for setting the CDC target field value, default is `{db}.{table}`  |
+
+# JsonToMapTransform
+_(Experimental)_ 
+
+The `JsonToMapTransform` SMT parses Json object payloads.  It is intended for use when the incoming data is too 
+inconsistent for the `iceberg-connector` to infer `Struct` schemas from (e.g. the object keys are too variable 
+and this leads to an explosion of schema evoltions and columns).  This will get the data into Iceberg where it can 
+be further processed by query engines into a more manageable form.  
+
+It will parse string values into `SinkRecords` with a Schema and a Struct.  It assumes the messages are json objects 
+themselves and will throw exceptions if the records are primitives. 
+
+## Configuration
+
+| Property             | Description  (default value)             |
+|----------------------|------------------------------------------|
+| transforms.json.root | (false) Boolean value to start at root   |
+
+The `transform.json.root` is meant for the most inconsistent data.  It will construct a Struct with a single field 
+called `payload` with a Schema of `Map<String, String>`.  
+
+If `transform.json.root` is false (the default), it will construct a Struct with inferred schemas for primitive and
+array fields.  Nested objects become fields of type `Map<String, String>`.
+
+Keys with empty arrays and empty objects are filtered out from the final schema.  Arrays will be typed unless the 
+json arrays have mixed types in which case they are converted to arrays of strings.
+
+Example json: 
+
+```json
+{
+  "key": 1, 
+  "array": [1,"two",3],
+  "empty_obj": {},
+  "nested_obj": {"some_key": ["one", "two"]}
+}
+```
+
+Will become the following if `transform.json.root` is true:
+
+```
+SinkRecord.schema: 
+  "payload" : (Optional) Map<String, String>
+  
+Sinkrecord.value: 
+  "payload" (Map<String, String>) : "{"key":1,"array":[1,"two",3],"empty_obj":{},"nested_obj":{"some_key":["one","two"]}}
+```
+
+Will become the following if `transform.json.root` is false
+
+```
+SinkRecord.schema: 
+  "key": (Optional) Int32,
+  "array": (Optional) Array<String>,
+  "nested_object": (Optional) Map<string, String>
+  
+SinkRecord.value:
+ "key" 1, 
+ "array" ["1", "two", "3"] 
+ "nested_object" Map ("some_key" : "["one", "two"]") 
+```

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapException.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transforms;
+
+class JsonToMapException extends RuntimeException {
+  JsonToMapException(String errorMessage) {
+    super(errorMessage);
+  }
+
+  JsonToMapException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
+}

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
@@ -4,19 +4,25 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.*;
-import com.sun.org.apache.xalan.internal.xsltc.compiler.util.NodeType;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
-import java.util.Locale;
+import java.util.List;
 import java.util.Map.Entry;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 public class JsonToMapTransform<R extends ConnectRecord<R>> implements Transformation<R> {
 
@@ -34,6 +40,28 @@ public class JsonToMapTransform<R extends ConnectRecord<R>> implements Transform
                             1,
                             ConfigDef.Importance.MEDIUM,
                             "Positive value at which level in the json to convert to Map<String, String>");
+
+
+    private static final Schema ALL_JSON_SCHEMA = SchemaBuilder.struct().field("value", Schema.STRING_SCHEMA).build();
+
+    public static final Map<Class<? extends JsonNode>, Schema> JSON_NODE_TO_SCHEMA = getJsonNodeToSchema();
+
+    private static Map<Class<? extends JsonNode>, Schema> getJsonNodeToSchema() {
+        final Map<Class<? extends JsonNode>, Schema> map = Maps.newHashMap();
+        map.put(BinaryNode.class, Schema.OPTIONAL_BYTES_SCHEMA);
+        map.put(BooleanNode.class, Schema.OPTIONAL_BOOLEAN_SCHEMA);
+        map.put(TextNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        map.put(IntNode.class, Schema.OPTIONAL_INT32_SCHEMA);
+        map.put(LongNode.class, Schema.OPTIONAL_INT64_SCHEMA);
+        map.put(FloatNode.class, Schema.OPTIONAL_FLOAT32_SCHEMA);
+        map.put(DoubleNode.class, Schema.OPTIONAL_FLOAT64_SCHEMA);
+        map.put(ArrayNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        map.put(ObjectNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        map.put(BigIntegerNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        map.put(DecimalNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        return ImmutableMap.copyOf(map);
+    }
+
     @Override
     public R apply(R record) {
         if (record.value() == null) {
@@ -51,103 +79,141 @@ public class JsonToMapTransform<R extends ConnectRecord<R>> implements Transform
 
         String json = (String) record.value();
         JsonNode obj;
+
         try {
             obj = mapper.readTree(json);
-        } catch (Exception unused) {
-            return newNullRecord(record);
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("record.value is not valid json for record.value: %s", collectRecordDetails(record)), e);
         }
 
         if (!(obj instanceof ObjectNode)) {
-            return newNullRecord(record);
+            throw new RuntimeException(String.format("Expected Json Object for record.value: %s", collectRecordDetails(record)));
+        }
+
+        if (JSON_LEVEL_VALUE == 0) {
+            // return the json as a single field, after validating it's actually json
+            return singleField(record);
         }
 
         return record;
     }
 
-    private R walk(R record, ObjectNode node) {
-
-        SchemaBuilder builder = SchemaBuilder.struct();
-
-        node.fields().forEachRemaining(a ->{
-          String name = a.getKey();
-          JsonNode currentNode = a.getValue();
-
-          if (!(currentNode instanceof ObjectNode)) {
-
-            }
-        }
-
+    private R singleField(R record) {
+        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), ALL_JSON_SCHEMA, record.value(), record.timestamp(), record.headers());
     }
 
-    public void addFieldSchema(Entry<String, JsonNode> kv, SchemaBuilder builder) {
+    private R structRecord(R record, ObjectNode contents) {
+        SchemaBuilder builder = SchemaBuilder.struct();
+        contents.fields().forEachRemaining(entry -> addFieldSchemaBuilder(entry, builder));
+        Schema schema = builder.build();
+        Struct value = addToStruct(contents, schema, new Struct(schema));
+        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), schema, value, record.timestamp(), record.headers());
+    }
+
+    private String collectRecordDetails(R record) {
+        if (record instanceof SinkRecord) {
+            SinkRecord sinkRecord = (SinkRecord) record;
+            return            String.format("topic %s partition %s offset %s", sinkRecord.topic(), sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset());
+        } else {
+            return String.format("topic %s partition %S", record.topic(), record.kafkaPartition());
+        }
+    }
+
+    private void addFieldSchemaBuilder(Entry<String, JsonNode> kv, SchemaBuilder builder) {
         String key = kv.getKey();
         JsonNode value = kv.getValue();
-        if (value.isNull()) {
-
-        } else if (value.isInt()) {
-            builder.field(key, SchemaBuilder.OPTIONAL_INT32_SCHEMA);
-        } else if (value.isLong()) {
-            builder.field(key, SchemaBuilder.OPTIONAL_INT64_SCHEMA);
-        } else if (value.isTextual()) {
-            builder.field(key, SchemaBuilder.OPTIONAL_STRING_SCHEMA);
-        } else if (value.isFloat()) {
-            builder.field(key, SchemaBuilder.OPTIONAL_FLOAT32_SCHEMA);
-        } else if (value.isDouble()) {
-            builder.field(key, SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA);
-        } else if (value.isBoolean()) {
-            builder.field(key, SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
-        } else if (value.isMissingNode()) {
-            // not sure that this can exist
-        } else if (value.isObject()) {
-            // nested time
-        } else if (value.isArray()) {
-            // array time, need to confirm all records are of the same type.
-            ArrayNode arr = (ArrayNode) value;
-            if (!arr.isEmpty()) {
-                JsonNodeType arrType = null;
-                nodeType = arr.elements().forEachRemaining();
-                builder.field(key, SchemaBuilder.array(arr.values).optional().build());
-            }
-        }
-        else if (value.isBigInteger()) {
-            // not sure, convert to string?
-        } else if (value.isBigDecimal()) {
-            // not sure, convert to string?
-        } else if (value.isBinary()) {
-            // is this a base64 or base64 URL encoded string>
-            builder.field(key, SchemaBuilder.BYTES_SCHEMA);
-            // not sure, convert to string?
-        }
-    }
-
-    private void determineArrayType(String fieldName, ArrayNode array, SchemaBuilder builder) {
-        if (!array.isEmpty()) {
-            final JsonNodeType[] arrType = {null};
-            final boolean[] forAll = {true};
-            array.elements().forEachRemaining(node -> {
-                JsonNodeType type = node.getNodeType();
-                if (arrType[0] == null) {
-                    arrType[0] = node.getNodeType();
+        if (!value.isNull() || !value.isMissingNode()) {
+            if (value.isArray()) {
+                // array time, need to confirm all records are of the same type.
+                ArrayNode array = (ArrayNode) value;
+                if (!array.isEmpty()) {
+                    Class<? extends JsonNode> arrayType = determineArrayNodeType(array);
+                    if (arrayType != null) {
+                        if (JsonNodeType.NULL.equals(arrayType) || JsonNodeType.MISSING.equals(arrayType)) {
+                            builder.field(key, SchemaBuilder.array(JSON_NODE_TO_SCHEMA.get(arrayType)).optional().build());
+                        } else {
+                            builder.field(key, SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
+                        }
+                    }
                 }
-                if (type != arrType[0]) {
-                    forAll[0] = false;
-                }
-            });
-
-            if (arrType[0] == JsonNodeType.ARRAY) {
-
-            } else if (arrType[0] == JsonNodeType.OBJECT) {
-
             } else {
-                builder.field(fieldName, schemaFromPrimitive(arrType[0]));
+                builder.field(key, JSON_NODE_TO_SCHEMA.get(value.getClass()));
             }
         }
-
-
     }
 
-    private Schema schemaFromPrimitive(JsonNodeType node) {
-        return null;
+    // handle the empty object cast?
+    private Class<? extends JsonNode> determineArrayNodeType(ArrayNode array) {
+        final List<Class<? extends JsonNode>> arrayType = Lists.newArrayList();
+        arrayType.add(null);
+        final boolean[] allTypesConsistent = {true};
+        // breaks on number.
+        array.elements().forEachRemaining(node -> {
+            Class<? extends JsonNode> type = node.getClass();
+            if (arrayType.get(0) == null) {
+                arrayType.set(0,type);
+            }
+            if (type != arrayType.get(0)) {
+                allTypesConsistent[0] = false;
+            }
+        });
+
+        if (!allTypesConsistent[0]) {
+            return null;
+        }
+        return arrayType.get(0);
+    }
+
+    private Struct addToStruct(ObjectNode node, Schema schema, Struct struct) {
+        schema.fields().forEach(field -> {
+            JsonNode element = node.get(field.name());
+            // adding primitives other than the weird array of primitive case
+            Schema.Type targetType = field.schema().type();
+            if (Objects.requireNonNull(targetType) == Schema.Type.ARRAY) {
+                Schema.Type arrayType = field.schema().valueSchema().type();
+                List<Object> elements = Lists.newArrayList();
+                element.elements().forEachRemaining(arrayEntry -> elements.add(primitiveBasedOnSchema(arrayEntry, arrayType, field.name())));
+                struct.put(field.name(), elements);
+            } else {
+                struct.put(field.name(), primitiveBasedOnSchema(element, targetType, field.name()));
+            }
+        });
+        return struct;
+    }
+
+    private Object primitiveBasedOnSchema(JsonNode node, Schema.Type type, String fieldName) {
+        Object obj;
+        switch (type) {
+            case STRING:
+                obj = node.toString();
+                break;
+            case BOOLEAN:
+                obj = node.booleanValue();
+                break;
+            case INT32:
+                obj = node.intValue();
+                break;
+            case INT64:
+                obj = node.longValue();
+                break;
+            case FLOAT32:
+                obj = node.floatValue();
+                break;
+            case FLOAT64:
+                obj = node.doubleValue();
+                break;
+            case BYTES:
+                // not sure here if you dig out
+                try {
+                    obj = node.binaryValue();
+                } catch (Exception e) {
+                    throw new RuntimeException(String.format("parsing binary value threw exception for %s", fieldName), e);
+                }
+                break;
+            default:
+                throw new RuntimeException(String.format("Unexpected type %s for field %s", type, fieldName));
+        }
+        return obj;
     }
 
     @Override

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
@@ -114,9 +114,7 @@ public class JsonToMapTransform<R extends ConnectRecord<R>> implements Transform
 
   private R structRecord(R record, ObjectNode contents) {
     SchemaBuilder builder = SchemaBuilder.struct();
-    contents
-        .fields()
-        .forEachRemaining(entry -> JsonToMapUtils.addFieldSchemaBuilder(entry, builder));
+    contents.fields().forEachRemaining(entry -> JsonToMapUtils.addField(entry, builder));
     Schema schema = builder.build();
     Struct value = JsonToMapUtils.addToStruct(contents, schema, new Struct(schema));
     return record.newRecord(

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
@@ -1,9 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.tabular.iceberg.connect.transforms;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.node.*;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -14,111 +33,135 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
-import java.util.Map;
-
 public class JsonToMapTransform<R extends ConnectRecord<R>> implements Transformation<R> {
 
-    public static final String JSON_LEVEL = "transforms.json.level";
+  public static final String JSON_LEVEL = "transforms.json.level";
 
-    private static final ObjectReader mapper = new ObjectMapper().reader();
+  private static final ObjectReader mapper = new ObjectMapper().reader();
 
-    private int JSON_LEVEL_VALUE = 1;
+  private int jsonLevel = 1;
 
-    public static final ConfigDef CONFIG_DEF =
-            new ConfigDef()
-                    .define(
-                            JSON_LEVEL,
-                            ConfigDef.Type.INT,
-                            1,
-                            ConfigDef.Importance.MEDIUM,
-                            "Positive value after which level in the json to convert to Map<String, String>");
+  public static final ConfigDef CONFIG_DEF =
+      new ConfigDef()
+          .define(
+              JSON_LEVEL,
+              ConfigDef.Type.INT,
+              1,
+              ConfigDef.Importance.MEDIUM,
+              "Positive value after which level in the json to convert to Map<String, String>");
 
+  private static final String ALL_JSON_SCHEMA_FIELD = "payload";
+  private static final Schema ALL_JSON_SCHEMA =
+      SchemaBuilder.struct().field(ALL_JSON_SCHEMA_FIELD, Schema.STRING_SCHEMA).build();
 
-    private static final String ALL_JSON_SCHEMA_FIELD = "payload";
-    private static final Schema ALL_JSON_SCHEMA = SchemaBuilder.struct().field(ALL_JSON_SCHEMA_FIELD, Schema.STRING_SCHEMA).build();
+  @Override
+  public R apply(R record) {
+    if (record.value() == null) {
+      return record;
+    } else {
+      return process(record);
+    }
+  }
 
-
-    @Override
-    public R apply(R record) {
-        if (record.value() == null) {
-            return record;
-        } else {
-            return process(record);
-        }
+  private R process(R record) {
+    if (!(record.value() instanceof String)) {
+      // filter out non-string messages
+      return newNullRecord(record);
     }
 
-    private R process(R record) {
-        if (!(record.value() instanceof String)) {
-            // filter out non-string messages
-            return newNullRecord(record);
-        }
+    String json = (String) record.value();
+    JsonNode obj;
 
-        String json = (String) record.value();
-        JsonNode obj;
-
-        try {
-            obj = mapper.readTree(json);
-        } catch (Exception e) {
-            throw new RuntimeException(String.format("record.value is not valid json for record.value: %s", collectRecordDetails(record)), e);
-        }
-
-        if (!(obj instanceof ObjectNode)) {
-            throw new RuntimeException(String.format("Expected json object for record.value: %s", collectRecordDetails(record)));
-        }
-
-        if (JSON_LEVEL_VALUE == 0) {
-            // return the json as a single field, after validating it's actually json
-            return singleField(record);
-        }
-
-        return structRecord(record, (ObjectNode) obj);
+    try {
+      obj = mapper.readTree(json);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format(
+              "record.value is not valid json for record.value: %s", collectRecordDetails(record)),
+          e);
     }
 
-    private R singleField(R record) {
-        Struct struct = new Struct(ALL_JSON_SCHEMA).put(ALL_JSON_SCHEMA_FIELD, record.value());
-        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), ALL_JSON_SCHEMA, struct, record.timestamp(), record.headers());
+    if (!(obj instanceof ObjectNode)) {
+      throw new RuntimeException(
+          String.format("Expected json object for record.value: %s", collectRecordDetails(record)));
     }
 
-    private R structRecord(R record, ObjectNode contents) {
-        SchemaBuilder builder = SchemaBuilder.struct();
-        contents.fields().forEachRemaining(entry -> JsonToMapUtils.addFieldSchemaBuilder(entry, builder));
-        Schema schema = builder.build();
-        Struct value = JsonToMapUtils.addToStruct(contents, schema, new Struct(schema));
-        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), schema, value, record.timestamp(), record.headers());
+    if (jsonLevel == 0) {
+      // return the json as a single field, after validating it's actually json
+      return singleField(record);
     }
 
-    private String collectRecordDetails(R record) {
-        if (record instanceof SinkRecord) {
-            SinkRecord sinkRecord = (SinkRecord) record;
-            return            String.format("topic %s partition %s offset %s", sinkRecord.topic(), sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset());
-        } else {
-            return String.format("topic %s partition %S", record.topic(), record.kafkaPartition());
-        }
+    return structRecord(record, (ObjectNode) obj);
+  }
+
+  private R singleField(R record) {
+    Struct struct = new Struct(ALL_JSON_SCHEMA).put(ALL_JSON_SCHEMA_FIELD, record.value());
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        ALL_JSON_SCHEMA,
+        struct,
+        record.timestamp(),
+        record.headers());
+  }
+
+  private R structRecord(R record, ObjectNode contents) {
+    SchemaBuilder builder = SchemaBuilder.struct();
+    contents
+        .fields()
+        .forEachRemaining(entry -> JsonToMapUtils.addFieldSchemaBuilder(entry, builder));
+    Schema schema = builder.build();
+    Struct value = JsonToMapUtils.addToStruct(contents, schema, new Struct(schema));
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        schema,
+        value,
+        record.timestamp(),
+        record.headers());
+  }
+
+  private String collectRecordDetails(R record) {
+    if (record instanceof SinkRecord) {
+      SinkRecord sinkRecord = (SinkRecord) record;
+      return String.format(
+          "topic %s partition %s offset %s",
+          sinkRecord.topic(), sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset());
+    } else {
+      return String.format("topic %s partition %S", record.topic(), record.kafkaPartition());
     }
+  }
 
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
 
+  private R newNullRecord(R record) {
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        null,
+        null,
+        null,
+        null,
+        record.timestamp(),
+        record.headers());
+  }
 
-    @Override
-    public ConfigDef config() {
-        return CONFIG_DEF;
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    SimpleConfig config = new SimpleConfig(CONFIG_DEF, configs);
+    jsonLevel = config.getInt(JSON_LEVEL);
+    if (jsonLevel < 0) {
+      throw new ConfigException(String.format("%s must be >= 0", JSON_LEVEL));
     }
-
-    private R newNullRecord(R record) {
-        return record.newRecord(record.topic(), record.kafkaPartition(), null, null, null, null, record.timestamp(), record.headers());
-    }
-
-    @Override
-    public void close() {
-
-    }
-
-    @Override
-    public void configure(Map<String, ?> configs) {
-        SimpleConfig config = new SimpleConfig(CONFIG_DEF, configs);
-        JSON_LEVEL_VALUE = config.getInt(JSON_LEVEL);
-        if (JSON_LEVEL_VALUE < 0){
-            throw new ConfigException(String.format("%s must be >= 0",JSON_LEVEL));
-        }
-
-    }
+  }
 }

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
@@ -1,0 +1,176 @@
+package io.tabular.iceberg.connect.transforms;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.node.*;
+import com.sun.org.apache.xalan.internal.xsltc.compiler.util.NodeType;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.Locale;
+import java.util.Map.Entry;
+
+import java.util.Map;
+
+public class JsonToMapTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    private static final String JSON_LEVEL = "transforms.json.level";
+
+    private static final ObjectReader mapper = new ObjectMapper().reader();
+
+    private int JSON_LEVEL_VALUE;
+
+    public static final ConfigDef CONFIG_DEF =
+            new ConfigDef()
+                    .define(
+                            JSON_LEVEL,
+                            ConfigDef.Type.INT,
+                            1,
+                            ConfigDef.Importance.MEDIUM,
+                            "Positive value at which level in the json to convert to Map<String, String>");
+    @Override
+    public R apply(R record) {
+        if (record.value() == null) {
+            return record;
+        } else {
+            return process(record);
+        }
+    }
+
+    private R process(R record) {
+        if (!(record.value() instanceof String)) {
+            // filter out non-string messages
+            return newNullRecord(record);
+        }
+
+        String json = (String) record.value();
+        JsonNode obj;
+        try {
+            obj = mapper.readTree(json);
+        } catch (Exception unused) {
+            return newNullRecord(record);
+        }
+
+        if (!(obj instanceof ObjectNode)) {
+            return newNullRecord(record);
+        }
+
+        return record;
+    }
+
+    private R walk(R record, ObjectNode node) {
+
+        SchemaBuilder builder = SchemaBuilder.struct();
+
+        node.fields().forEachRemaining(a ->{
+          String name = a.getKey();
+          JsonNode currentNode = a.getValue();
+
+          if (!(currentNode instanceof ObjectNode)) {
+
+            }
+        }
+
+    }
+
+    public void addFieldSchema(Entry<String, JsonNode> kv, SchemaBuilder builder) {
+        String key = kv.getKey();
+        JsonNode value = kv.getValue();
+        if (value.isNull()) {
+
+        } else if (value.isInt()) {
+            builder.field(key, SchemaBuilder.OPTIONAL_INT32_SCHEMA);
+        } else if (value.isLong()) {
+            builder.field(key, SchemaBuilder.OPTIONAL_INT64_SCHEMA);
+        } else if (value.isTextual()) {
+            builder.field(key, SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        } else if (value.isFloat()) {
+            builder.field(key, SchemaBuilder.OPTIONAL_FLOAT32_SCHEMA);
+        } else if (value.isDouble()) {
+            builder.field(key, SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA);
+        } else if (value.isBoolean()) {
+            builder.field(key, SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
+        } else if (value.isMissingNode()) {
+            // not sure that this can exist
+        } else if (value.isObject()) {
+            // nested time
+        } else if (value.isArray()) {
+            // array time, need to confirm all records are of the same type.
+            ArrayNode arr = (ArrayNode) value;
+            if (!arr.isEmpty()) {
+                JsonNodeType arrType = null;
+                nodeType = arr.elements().forEachRemaining();
+                builder.field(key, SchemaBuilder.array(arr.values).optional().build());
+            }
+        }
+        else if (value.isBigInteger()) {
+            // not sure, convert to string?
+        } else if (value.isBigDecimal()) {
+            // not sure, convert to string?
+        } else if (value.isBinary()) {
+            // is this a base64 or base64 URL encoded string>
+            builder.field(key, SchemaBuilder.BYTES_SCHEMA);
+            // not sure, convert to string?
+        }
+    }
+
+    private void determineArrayType(String fieldName, ArrayNode array, SchemaBuilder builder) {
+        if (!array.isEmpty()) {
+            final JsonNodeType[] arrType = {null};
+            final boolean[] forAll = {true};
+            array.elements().forEachRemaining(node -> {
+                JsonNodeType type = node.getNodeType();
+                if (arrType[0] == null) {
+                    arrType[0] = node.getNodeType();
+                }
+                if (type != arrType[0]) {
+                    forAll[0] = false;
+                }
+            });
+
+            if (arrType[0] == JsonNodeType.ARRAY) {
+
+            } else if (arrType[0] == JsonNodeType.OBJECT) {
+
+            } else {
+                builder.field(fieldName, schemaFromPrimitive(arrType[0]));
+            }
+        }
+
+
+    }
+
+    private Schema schemaFromPrimitive(JsonNodeType node) {
+        return null;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    private R newNullRecord(R record) {
+        return record.newRecord(record.topic(), record.kafkaPartition(), null, null, null, null, record.timestamp(), record.headers());
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        SimpleConfig config = new SimpleConfig(CONFIG_DEF, configs);
+        JSON_LEVEL_VALUE = config.getInt(JSON_LEVEL);
+        if (JSON_LEVEL_VALUE < 0){
+            throw new ConfigException(String.format("%s must be >= 0",JSON_LEVEL));
+        }
+
+    }
+}

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapTransform.java
@@ -48,7 +48,7 @@ public class JsonToMapTransform<R extends ConnectRecord<R>> implements Transform
               ConfigDef.Type.BOOLEAN,
               false,
               ConfigDef.Importance.MEDIUM,
-              "Boolean value to start at root.  False is one level in from the root");
+              "Boolean value to start at root. False is one level in from the root");
 
   private static final String ALL_JSON_SCHEMA_FIELD = "payload";
   private static final Schema JSON_MAP_SCHEMA =

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
@@ -252,7 +252,7 @@ class JsonToMapUtils {
         obj = extractBytes(node, fieldName);
         break;
       default:
-        throw new RuntimeException(
+        throw new JsonToMapException(
             String.format("Unexpected type %s for field %s", type, fieldName));
     }
     return obj;
@@ -269,7 +269,7 @@ class JsonToMapUtils {
         obj = node.binaryValue();
       }
     } catch (Exception e) {
-      throw new RuntimeException(
+      throw new JsonToMapException(
           String.format("parsing binary value threw exception for %s", fieldName), e);
     }
     return obj;

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
@@ -32,6 +32,8 @@ import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +51,7 @@ public class JsonToMapUtils {
   }
 
   private static final Map<Class<? extends JsonNode>, Schema> JSON_NODE_TO_SCHEMA =
-      getJsonNodeToSchema();
+          getJsonNodeToSchema();
 
   private static Map<Class<? extends JsonNode>, Schema> getJsonNodeToSchema() {
     final Map<Class<? extends JsonNode>, Schema> map = Maps.newHashMap();
@@ -61,7 +63,7 @@ public class JsonToMapUtils {
     map.put(FloatNode.class, Schema.OPTIONAL_FLOAT32_SCHEMA);
     map.put(DoubleNode.class, Schema.OPTIONAL_FLOAT64_SCHEMA);
     map.put(ArrayNode.class, Schema.OPTIONAL_STRING_SCHEMA);
-    map.put(ObjectNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+    map.put(ObjectNode.class, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build());
     map.put(BigIntegerNode.class, Schema.OPTIONAL_STRING_SCHEMA);
     map.put(DecimalNode.class, Schema.OPTIONAL_STRING_SCHEMA);
     return ImmutableMap.copyOf(map);
@@ -74,7 +76,7 @@ public class JsonToMapUtils {
   }
 
   public static SchemaBuilder addFieldSchemaBuilder(
-      Map.Entry<String, JsonNode> kv, SchemaBuilder builder) {
+          Map.Entry<String, JsonNode> kv, SchemaBuilder builder) {
     String key = kv.getKey();
     JsonNode value = kv.getValue();
     addToSchema(key, schemaFromNode(value), builder);
@@ -85,75 +87,79 @@ public class JsonToMapUtils {
   public static Schema schemaFromNode(JsonNode node) {
     if (!node.isNull() && !node.isMissingNode()) {
       if (node.isArray()) {
-        ArrayNode array = (ArrayNode) node;
-        // can't create a schema for an empty array since the inner type is not known.
-        if (!array.isEmpty()) {
-          Class<? extends JsonNode> arrayType = arrayNodeType(array);
-          if (arrayType != null) {
-            if (arrayType != NullNode.class && arrayType != MissingNode.class) {
-              if (arrayType == ObjectNode.class) {
-                // arrays of objects become strings
-                int objectCount = 0;
-                int emptyObjectCount = 0;
-                for (Iterator<JsonNode> it = array.elements(); it.hasNext(); ) {
-                  JsonNode element = it.next();
-                  objectCount += 1;
-                  if (!element.elements().hasNext()) {
-                    emptyObjectCount += 1;
-                  }
-                }
-                if (objectCount == emptyObjectCount) {
-                  return null;
-                } else {
-                  return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
-                }
-              } else if (arrayType == ArrayNode.class) {
-                // nested array case
-                // need to protect against arrays of empty arrays, arrays of empty objects, arrays
-                // inconsistent types, etc.
-                List<Schema> nestedSchemas = Lists.newArrayList();
-                boolean[] hasValidSchema = {true};
-                node.elements()
-                    .forEachRemaining(
-                        nodeElement -> {
-                          Schema nestedElementSchema = schemaFromNode(nodeElement);
-                          if (nestedElementSchema == null) {
-                            hasValidSchema[0] = false;
-                          }
-                          nestedSchemas.add(nestedElementSchema);
-                        });
-                if (!nestedSchemas.isEmpty() && hasValidSchema[0]) {
-                  boolean allMatch =
-                      nestedSchemas.stream()
-                          .allMatch(schema -> schema.equals(nestedSchemas.get(0)));
-                  if (allMatch) {
-                    return SchemaBuilder.array(nestedSchemas.get(0)).optional().build();
-                  } else {
-                    return SchemaBuilder.array(
-                            SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
-                        .optional()
-                        .build();
-                  }
-                } else {
-                  return null;
-                }
-              } else {
-
-                // if we are a consistent primitive
-                return SchemaBuilder.array(JSON_NODE_TO_SCHEMA.get(arrayType)).optional().build();
-              }
-            }
-          } else {
-            // if types of the array are inconsistent, convert to a string
-            return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
-          }
-        }
+        return arraySchema((ArrayNode) node);
       } else if (node.isObject()) {
         if (node.elements().hasNext()) {
           return JSON_NODE_TO_SCHEMA.get(node.getClass());
         }
       } else {
         return JSON_NODE_TO_SCHEMA.get(node.getClass());
+      }
+    }
+    return null;
+  }
+
+  private static Schema arraySchema(ArrayNode array) {
+    // can't create a schema for an empty array since the inner type is not known.
+    if (!array.isEmpty()) {
+      Class<? extends JsonNode> arrayType = arrayNodeType(array);
+      if (arrayType != null) {
+        if (arrayType != NullNode.class && arrayType != MissingNode.class) {
+          if (arrayType == ObjectNode.class) {
+            // arrays of objects become strings (and mixed arrays containing one object)
+            // need to protect against arrays of empty objects
+            int objectCount = 0;
+            int emptyObjectCount = 0;
+            for (Iterator<JsonNode> it = array.elements(); it.hasNext(); ) {
+              JsonNode element = it.next();
+              objectCount += 1;
+              if (!element.elements().hasNext()) {
+                emptyObjectCount += 1;
+              }
+            }
+            if (objectCount == emptyObjectCount) {
+              return null;
+            } else {
+              return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+            }
+          } else if (arrayType == ArrayNode.class) {
+            // nested array case
+            // need to protect against arrays of empty arrays, arrays of empty objects, arrays
+            // inconsistent types, etc.
+            List<Schema> nestedSchemas = Lists.newArrayList();
+            boolean[] hasValidSchema = {true};
+            array.elements()
+                    .forEachRemaining(
+                            nodeElement -> {
+                              Schema nestedElementSchema = schemaFromNode(nodeElement);
+                              if (nestedElementSchema == null) {
+                                hasValidSchema[0] = false;
+                              }
+                              nestedSchemas.add(nestedElementSchema);
+                            });
+            if (!nestedSchemas.isEmpty() && hasValidSchema[0]) {
+              boolean allMatch =
+                      nestedSchemas.stream()
+                              .allMatch(schema -> schema.equals(nestedSchemas.get(0)));
+              if (allMatch) {
+                return SchemaBuilder.array(nestedSchemas.get(0)).optional().build();
+              } else {
+                return SchemaBuilder.array(
+                                SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
+                        .optional()
+                        .build();
+              }
+            } else {
+              return null;
+            }
+          } else {
+            // we are a consistent primitive
+            return SchemaBuilder.array(JSON_NODE_TO_SCHEMA.get(arrayType)).optional().build();
+          }
+        }
+      } else {
+        // if types of the array are inconsistent, convert to a string
+        return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
       }
     }
     return null;
@@ -166,17 +172,17 @@ public class JsonToMapUtils {
     final boolean[] allTypesConsistent = {true};
     // breaks on number.
     array
-        .elements()
-        .forEachRemaining(
-            node -> {
-              Class<? extends JsonNode> type = node.getClass();
-              if (arrayType.get(0) == null) {
-                arrayType.set(0, type);
-              }
-              if (type != arrayType.get(0)) {
-                allTypesConsistent[0] = false;
-              }
-            });
+            .elements()
+            .forEachRemaining(
+                    node -> {
+                      Class<? extends JsonNode> type = node.getClass();
+                      if (arrayType.get(0) == null) {
+                        arrayType.set(0, type);
+                      }
+                      if (type != arrayType.get(0)) {
+                        allTypesConsistent[0] = false;
+                      }
+                    });
 
     if (!allTypesConsistent[0]) {
       return null;
@@ -187,20 +193,22 @@ public class JsonToMapUtils {
 
   public static Struct addToStruct(ObjectNode node, Schema schema, Struct struct) {
     schema
-        .fields()
-        .forEach(
-            field -> {
-              JsonNode element = node.get(field.name());
-              Schema.Type targetType = field.schema().type();
-              if (targetType == Schema.Type.ARRAY) {
-                struct.put(
-                    field.name(),
-                    populateArray(
-                        element, field.schema().valueSchema(), field.name(), Lists.newArrayList()));
-              } else {
-                struct.put(field.name(), extractSimpleValue(element, targetType, field.name()));
-              }
-            });
+            .fields()
+            .forEach(
+                    field -> {
+                      JsonNode element = node.get(field.name());
+                      Schema.Type targetType = field.schema().type();
+                      if (targetType == Schema.Type.ARRAY) {
+                        struct.put(
+                                field.name(),
+                                populateArray(
+                                        element, field.schema().valueSchema(), field.name(), Lists.newArrayList()));
+                      } else if (targetType == Schema.Type.MAP) {
+                        struct.put(field.name(), populateMap(element, Maps.newHashMap()));
+                      } else {
+                        struct.put(field.name(), extractSimpleValue(element, targetType, field.name()));
+                      }
+                    });
     return struct;
   }
 
@@ -208,11 +216,7 @@ public class JsonToMapUtils {
     Object obj;
     switch (type) {
       case STRING:
-        if (node.isTextual()) {
-          obj = node.textValue();
-        } else {
-          obj = node.toString();
-        }
+        obj = nodeToText(node);
         break;
       case BOOLEAN:
         obj = node.booleanValue();
@@ -234,18 +238,18 @@ public class JsonToMapUtils {
           obj = node.binaryValue();
         } catch (Exception e) {
           throw new RuntimeException(
-              String.format("parsing binary value threw exception for %s", fieldName), e);
+                  String.format("parsing binary value threw exception for %s", fieldName), e);
         }
         break;
       default:
         throw new RuntimeException(
-            String.format("Unexpected type %s for field %s", type, fieldName));
+                String.format("Unexpected type %s for field %s", type, fieldName));
     }
     return obj;
   }
 
   private static List<Object> populateArray(
-      JsonNode node, Schema schema, String fieldName, List<Object> acc) {
+          JsonNode node, Schema schema, String fieldName, List<Object> acc) {
     if (schema.type() == Schema.Type.ARRAY) {
       for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
         JsonNode arrayNode = it.next();
@@ -254,9 +258,27 @@ public class JsonToMapUtils {
       }
     } else {
       node.elements()
-          .forEachRemaining(
-              arrayEntry -> acc.add(extractSimpleValue(arrayEntry, schema.type(), fieldName)));
+              .forEachRemaining(
+                      arrayEntry -> acc.add(extractSimpleValue(arrayEntry, schema.type(), fieldName)));
     }
     return acc;
+  }
+
+  public static HashMap<String, String> populateMap(
+          JsonNode node, HashMap<String, String> map
+  ) {
+    for (Iterator<Map.Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
+      Map.Entry<String, JsonNode> element = it.next();
+      map.put(element.getKey(), nodeToText(element.getValue()));
+    }
+    return map;
+  }
+
+  private static String nodeToText(JsonNode node) {
+    if (node.isTextual()) {
+      return node.textValue();
+    } else {
+      return node.toString();
+    }
   }
 }

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
@@ -74,8 +74,6 @@ class JsonToMapUtils {
     map.put(IntNode.class, Schema.OPTIONAL_INT32_SCHEMA);
     map.put(LongNode.class, Schema.OPTIONAL_INT64_SCHEMA);
     map.put(FloatNode.class, Schema.OPTIONAL_FLOAT32_SCHEMA);
-
-    // if it's bigger than double I don't have great options.
     map.put(DoubleNode.class, Schema.OPTIONAL_FLOAT64_SCHEMA);
     map.put(ArrayNode.class, Schema.OPTIONAL_STRING_SCHEMA);
     map.put(

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
@@ -1,7 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.tabular.iceberg.connect.transforms;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.*;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -9,193 +42,221 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
 public class JsonToMapUtils {
-    private static final Map<Class<? extends JsonNode>, Schema> JSON_NODE_TO_SCHEMA = getJsonNodeToSchema();
-    private static Map<Class<? extends JsonNode>, Schema> getJsonNodeToSchema() {
-        final Map<Class<? extends JsonNode>, Schema> map = Maps.newHashMap();
-        map.put(BinaryNode.class, Schema.OPTIONAL_BYTES_SCHEMA);
-        map.put(BooleanNode.class, Schema.OPTIONAL_BOOLEAN_SCHEMA);
-        map.put(TextNode.class, Schema.OPTIONAL_STRING_SCHEMA);
-        map.put(IntNode.class, Schema.OPTIONAL_INT32_SCHEMA);
-        map.put(LongNode.class, Schema.OPTIONAL_INT64_SCHEMA);
-        map.put(FloatNode.class, Schema.OPTIONAL_FLOAT32_SCHEMA);
-        map.put(DoubleNode.class, Schema.OPTIONAL_FLOAT64_SCHEMA);
-        map.put(ArrayNode.class, Schema.OPTIONAL_STRING_SCHEMA);
-        map.put(ObjectNode.class, Schema.OPTIONAL_STRING_SCHEMA);
-        map.put(BigIntegerNode.class, Schema.OPTIONAL_STRING_SCHEMA);
-        map.put(DecimalNode.class, Schema.OPTIONAL_STRING_SCHEMA);
-        return ImmutableMap.copyOf(map);
-    }
-    public static void addToSchema(String fieldName, Schema schema, SchemaBuilder builder) {
-        if (schema != null) {
-            builder.field(fieldName, schema);
-        }
-    }
 
-    public static SchemaBuilder addFieldSchemaBuilder(Map.Entry<String, JsonNode> kv, SchemaBuilder builder) {
-        String key = kv.getKey();
-        JsonNode value = kv.getValue();
-        addToSchema(key, schemaFromNode(value), builder);
-        return builder;
+  private JsonToMapUtils() {
+    throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+  }
+
+  private static final Map<Class<? extends JsonNode>, Schema> JSON_NODE_TO_SCHEMA =
+      getJsonNodeToSchema();
+
+  private static Map<Class<? extends JsonNode>, Schema> getJsonNodeToSchema() {
+    final Map<Class<? extends JsonNode>, Schema> map = Maps.newHashMap();
+    map.put(BinaryNode.class, Schema.OPTIONAL_BYTES_SCHEMA);
+    map.put(BooleanNode.class, Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    map.put(TextNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+    map.put(IntNode.class, Schema.OPTIONAL_INT32_SCHEMA);
+    map.put(LongNode.class, Schema.OPTIONAL_INT64_SCHEMA);
+    map.put(FloatNode.class, Schema.OPTIONAL_FLOAT32_SCHEMA);
+    map.put(DoubleNode.class, Schema.OPTIONAL_FLOAT64_SCHEMA);
+    map.put(ArrayNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+    map.put(ObjectNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+    map.put(BigIntegerNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+    map.put(DecimalNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+    return ImmutableMap.copyOf(map);
+  }
+
+  public static void addToSchema(String fieldName, Schema schema, SchemaBuilder builder) {
+    if (schema != null) {
+      builder.field(fieldName, schema);
     }
+  }
 
-    public static Schema schemaFromNode(JsonNode node) {
-        if (!node.isNull() && !node.isMissingNode()) {
-            if (node.isArray()) {
-                ArrayNode array = (ArrayNode) node;
-                // can't create a schema for an empty array since the inner type is not known.
-                if (!array.isEmpty()) {
-                    Class<? extends JsonNode> arrayType = arrayNodeType(array);
-                    if (arrayType != null) {
-                        if (arrayType != NullNode.class && arrayType != MissingNode.class) {
-                            if (arrayType == ObjectNode.class) {
-                                // arrays of objects become strings
-                                int objectCount = 0;
-                                int emptyObjectCount = 0;
-                                for (Iterator<JsonNode> it = array.elements(); it.hasNext(); ) {
-                                    JsonNode element = it.next();
-                                    objectCount += 1;
-                                    if (!element.elements().hasNext()) {
-                                       emptyObjectCount += 1;
-                                    }
-                                }
-                                if (objectCount == emptyObjectCount) {
-                                    return null;
-                                } else {
-                                    return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
-                                }
-                            } else if (arrayType == ArrayNode.class) {
-                                // nested array case
-                                // need to protect against arrays of empty arrays, arrays of empty objects, arrays inconsistent types, etc.
-                                List<Schema> nestedSchemas = Lists.newArrayList();
-                                boolean[] hasValidSchema = {true};
-                                node.elements().forEachRemaining(nodeElement -> {
-                                    Schema nestedElementSchema = schemaFromNode(nodeElement);
-                                    if (nestedElementSchema == null) {
-                                        hasValidSchema[0] = false;
-                                    }
-                                    nestedSchemas.add(nestedElementSchema);
-                                });
-                                if (!nestedSchemas.isEmpty() && hasValidSchema[0]) {
-                                    boolean allMatch = nestedSchemas.stream().allMatch(schema -> schema.equals(nestedSchemas.get(0)));
-                                    if (allMatch) {
-                                        return SchemaBuilder.array(nestedSchemas.get(0)).optional().build();
-                                    } else {
-                                        return SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build()).optional().build();
-                                    }
-                                } else {
-                                    return null;
-                                }
-                            } else {
+  public static SchemaBuilder addFieldSchemaBuilder(
+      Map.Entry<String, JsonNode> kv, SchemaBuilder builder) {
+    String key = kv.getKey();
+    JsonNode value = kv.getValue();
+    addToSchema(key, schemaFromNode(value), builder);
+    return builder;
+  }
 
-                                // if we are a consistent primitive
-                                return SchemaBuilder.array(JSON_NODE_TO_SCHEMA.get(arrayType)).optional().build();
-                            }
-                        }
-                    } else {
-                        // if types of the array are inconsistent, convert to a string
-                        return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
-                    }
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  public static Schema schemaFromNode(JsonNode node) {
+    if (!node.isNull() && !node.isMissingNode()) {
+      if (node.isArray()) {
+        ArrayNode array = (ArrayNode) node;
+        // can't create a schema for an empty array since the inner type is not known.
+        if (!array.isEmpty()) {
+          Class<? extends JsonNode> arrayType = arrayNodeType(array);
+          if (arrayType != null) {
+            if (arrayType != NullNode.class && arrayType != MissingNode.class) {
+              if (arrayType == ObjectNode.class) {
+                // arrays of objects become strings
+                int objectCount = 0;
+                int emptyObjectCount = 0;
+                for (Iterator<JsonNode> it = array.elements(); it.hasNext(); ) {
+                  JsonNode element = it.next();
+                  objectCount += 1;
+                  if (!element.elements().hasNext()) {
+                    emptyObjectCount += 1;
+                  }
                 }
-            } else if (node.isObject()) {
-                if (node.elements().hasNext()) {
-                    return JSON_NODE_TO_SCHEMA.get(node.getClass());
-                }
-            } else {
-                return JSON_NODE_TO_SCHEMA.get(node.getClass());
-            }
-        }
-        return null;
-    }
-
-    /* Kafka Connect arrays must all be the same type */
-    public static Class<? extends JsonNode> arrayNodeType(ArrayNode array) {
-        final List<Class<? extends JsonNode>> arrayType = Lists.newArrayList();
-        arrayType.add(null);
-        final boolean[] allTypesConsistent = {true};
-        // breaks on number.
-        array.elements().forEachRemaining(node -> {
-            Class<? extends JsonNode> type = node.getClass();
-            if (arrayType.get(0) == null) {
-                arrayType.set(0,type);
-            }
-            if (type != arrayType.get(0)) {
-                allTypesConsistent[0] = false;
-            }
-        });
-
-        if (!allTypesConsistent[0]) {
-            return null;
-        }
-
-        return arrayType.get(0);
-    }
-    public static Struct addToStruct(ObjectNode node, Schema schema, Struct struct) {
-        schema.fields().forEach(field -> {
-            JsonNode element = node.get(field.name());
-            Schema.Type targetType = field.schema().type();
-            if (targetType == Schema.Type.ARRAY) {
-                struct.put(field.name(), populateArray(element, field.schema().valueSchema(), field.name(), Lists.newArrayList()));
-            } else {
-                struct.put(field.name(), extractSimpleValue(element, targetType, field.name()));
-            }
-        });
-        return struct;
-    }
-
-    public static Object extractSimpleValue(JsonNode node, Schema.Type type, String fieldName) {
-        Object obj;
-        switch (type) {
-            case STRING:
-                if (node.isTextual()) {
-                    obj = node.textValue();
+                if (objectCount == emptyObjectCount) {
+                  return null;
                 } else {
-                    obj = node.toString();
+                  return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
                 }
-                break;
-            case BOOLEAN:
-                obj = node.booleanValue();
-                break;
-            case INT32:
-                obj = node.intValue();
-                break;
-            case INT64:
-                obj = node.longValue();
-                break;
-            case FLOAT32:
-                obj = node.floatValue();
-                break;
-            case FLOAT64:
-                obj = node.doubleValue();
-                break;
-            case BYTES:
-                try {
-                    obj = node.binaryValue();
-                } catch (Exception e) {
-                    throw new RuntimeException(String.format("parsing binary value threw exception for %s", fieldName), e);
+              } else if (arrayType == ArrayNode.class) {
+                // nested array case
+                // need to protect against arrays of empty arrays, arrays of empty objects, arrays
+                // inconsistent types, etc.
+                List<Schema> nestedSchemas = Lists.newArrayList();
+                boolean[] hasValidSchema = {true};
+                node.elements()
+                    .forEachRemaining(
+                        nodeElement -> {
+                          Schema nestedElementSchema = schemaFromNode(nodeElement);
+                          if (nestedElementSchema == null) {
+                            hasValidSchema[0] = false;
+                          }
+                          nestedSchemas.add(nestedElementSchema);
+                        });
+                if (!nestedSchemas.isEmpty() && hasValidSchema[0]) {
+                  boolean allMatch =
+                      nestedSchemas.stream()
+                          .allMatch(schema -> schema.equals(nestedSchemas.get(0)));
+                  if (allMatch) {
+                    return SchemaBuilder.array(nestedSchemas.get(0)).optional().build();
+                  } else {
+                    return SchemaBuilder.array(
+                            SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
+                        .optional()
+                        .build();
+                  }
+                } else {
+                  return null;
                 }
-                break;
-            default:
-                throw new RuntimeException(String.format("Unexpected type %s for field %s", type, fieldName));
+              } else {
+
+                // if we are a consistent primitive
+                return SchemaBuilder.array(JSON_NODE_TO_SCHEMA.get(arrayType)).optional().build();
+              }
+            }
+          } else {
+            // if types of the array are inconsistent, convert to a string
+            return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+          }
         }
-        return obj;
+      } else if (node.isObject()) {
+        if (node.elements().hasNext()) {
+          return JSON_NODE_TO_SCHEMA.get(node.getClass());
+        }
+      } else {
+        return JSON_NODE_TO_SCHEMA.get(node.getClass());
+      }
+    }
+    return null;
+  }
+
+  /* Kafka Connect arrays must all be the same type */
+  public static Class<? extends JsonNode> arrayNodeType(ArrayNode array) {
+    final List<Class<? extends JsonNode>> arrayType = Lists.newArrayList();
+    arrayType.add(null);
+    final boolean[] allTypesConsistent = {true};
+    // breaks on number.
+    array
+        .elements()
+        .forEachRemaining(
+            node -> {
+              Class<? extends JsonNode> type = node.getClass();
+              if (arrayType.get(0) == null) {
+                arrayType.set(0, type);
+              }
+              if (type != arrayType.get(0)) {
+                allTypesConsistent[0] = false;
+              }
+            });
+
+    if (!allTypesConsistent[0]) {
+      return null;
     }
 
-    private static List<Object> populateArray(JsonNode node, Schema schema, String fieldName, List<Object> acc) {
-        if (schema.type() == Schema.Type.ARRAY) {
-            for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
-                JsonNode arrayNode = it.next();
-                List<Object> nestedList = Lists.newArrayList();
-                acc.add(populateArray(arrayNode, schema.valueSchema(), fieldName, nestedList));
-            }
+    return arrayType.get(0);
+  }
+
+  public static Struct addToStruct(ObjectNode node, Schema schema, Struct struct) {
+    schema
+        .fields()
+        .forEach(
+            field -> {
+              JsonNode element = node.get(field.name());
+              Schema.Type targetType = field.schema().type();
+              if (targetType == Schema.Type.ARRAY) {
+                struct.put(
+                    field.name(),
+                    populateArray(
+                        element, field.schema().valueSchema(), field.name(), Lists.newArrayList()));
+              } else {
+                struct.put(field.name(), extractSimpleValue(element, targetType, field.name()));
+              }
+            });
+    return struct;
+  }
+
+  public static Object extractSimpleValue(JsonNode node, Schema.Type type, String fieldName) {
+    Object obj;
+    switch (type) {
+      case STRING:
+        if (node.isTextual()) {
+          obj = node.textValue();
         } else {
-            node.elements().forEachRemaining(arrayEntry -> acc.add(extractSimpleValue(arrayEntry, schema.type(), fieldName)));
+          obj = node.toString();
         }
-        return acc;
+        break;
+      case BOOLEAN:
+        obj = node.booleanValue();
+        break;
+      case INT32:
+        obj = node.intValue();
+        break;
+      case INT64:
+        obj = node.longValue();
+        break;
+      case FLOAT32:
+        obj = node.floatValue();
+        break;
+      case FLOAT64:
+        obj = node.doubleValue();
+        break;
+      case BYTES:
+        try {
+          obj = node.binaryValue();
+        } catch (Exception e) {
+          throw new RuntimeException(
+              String.format("parsing binary value threw exception for %s", fieldName), e);
+        }
+        break;
+      default:
+        throw new RuntimeException(
+            String.format("Unexpected type %s for field %s", type, fieldName));
     }
+    return obj;
+  }
+
+  private static List<Object> populateArray(
+      JsonNode node, Schema schema, String fieldName, List<Object> acc) {
+    if (schema.type() == Schema.Type.ARRAY) {
+      for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
+        JsonNode arrayNode = it.next();
+        List<Object> nestedList = Lists.newArrayList();
+        acc.add(populateArray(arrayNode, schema.valueSchema(), fieldName, nestedList));
+      }
+    } else {
+      node.elements()
+          .forEachRemaining(
+              arrayEntry -> acc.add(extractSimpleValue(arrayEntry, schema.type(), fieldName)));
+    }
+    return acc;
+  }
 }

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
@@ -32,8 +32,6 @@ import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +49,7 @@ public class JsonToMapUtils {
   }
 
   private static final Map<Class<? extends JsonNode>, Schema> JSON_NODE_TO_SCHEMA =
-          getJsonNodeToSchema();
+      getJsonNodeToSchema();
 
   private static Map<Class<? extends JsonNode>, Schema> getJsonNodeToSchema() {
     final Map<Class<? extends JsonNode>, Schema> map = Maps.newHashMap();
@@ -63,7 +61,9 @@ public class JsonToMapUtils {
     map.put(FloatNode.class, Schema.OPTIONAL_FLOAT32_SCHEMA);
     map.put(DoubleNode.class, Schema.OPTIONAL_FLOAT64_SCHEMA);
     map.put(ArrayNode.class, Schema.OPTIONAL_STRING_SCHEMA);
-    map.put(ObjectNode.class, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build());
+    map.put(
+        ObjectNode.class,
+        SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build());
     map.put(BigIntegerNode.class, Schema.OPTIONAL_STRING_SCHEMA);
     map.put(DecimalNode.class, Schema.OPTIONAL_STRING_SCHEMA);
     return ImmutableMap.copyOf(map);
@@ -76,14 +76,13 @@ public class JsonToMapUtils {
   }
 
   public static SchemaBuilder addFieldSchemaBuilder(
-          Map.Entry<String, JsonNode> kv, SchemaBuilder builder) {
+      Map.Entry<String, JsonNode> kv, SchemaBuilder builder) {
     String key = kv.getKey();
     JsonNode value = kv.getValue();
     addToSchema(key, schemaFromNode(value), builder);
     return builder;
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public static Schema schemaFromNode(JsonNode node) {
     if (!node.isNull() && !node.isMissingNode()) {
       if (node.isArray()) {
@@ -99,6 +98,7 @@ public class JsonToMapUtils {
     return null;
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   private static Schema arraySchema(ArrayNode array) {
     // can't create a schema for an empty array since the inner type is not known.
     if (!array.isEmpty()) {
@@ -128,26 +128,26 @@ public class JsonToMapUtils {
             // inconsistent types, etc.
             List<Schema> nestedSchemas = Lists.newArrayList();
             boolean[] hasValidSchema = {true};
-            array.elements()
-                    .forEachRemaining(
-                            nodeElement -> {
-                              Schema nestedElementSchema = schemaFromNode(nodeElement);
-                              if (nestedElementSchema == null) {
-                                hasValidSchema[0] = false;
-                              }
-                              nestedSchemas.add(nestedElementSchema);
-                            });
+            array
+                .elements()
+                .forEachRemaining(
+                    nodeElement -> {
+                      Schema nestedElementSchema = schemaFromNode(nodeElement);
+                      if (nestedElementSchema == null) {
+                        hasValidSchema[0] = false;
+                      }
+                      nestedSchemas.add(nestedElementSchema);
+                    });
             if (!nestedSchemas.isEmpty() && hasValidSchema[0]) {
               boolean allMatch =
-                      nestedSchemas.stream()
-                              .allMatch(schema -> schema.equals(nestedSchemas.get(0)));
+                  nestedSchemas.stream().allMatch(schema -> schema.equals(nestedSchemas.get(0)));
               if (allMatch) {
                 return SchemaBuilder.array(nestedSchemas.get(0)).optional().build();
               } else {
                 return SchemaBuilder.array(
-                                SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
-                        .optional()
-                        .build();
+                        SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
+                    .optional()
+                    .build();
               }
             } else {
               return null;
@@ -172,17 +172,17 @@ public class JsonToMapUtils {
     final boolean[] allTypesConsistent = {true};
     // breaks on number.
     array
-            .elements()
-            .forEachRemaining(
-                    node -> {
-                      Class<? extends JsonNode> type = node.getClass();
-                      if (arrayType.get(0) == null) {
-                        arrayType.set(0, type);
-                      }
-                      if (type != arrayType.get(0)) {
-                        allTypesConsistent[0] = false;
-                      }
-                    });
+        .elements()
+        .forEachRemaining(
+            node -> {
+              Class<? extends JsonNode> type = node.getClass();
+              if (arrayType.get(0) == null) {
+                arrayType.set(0, type);
+              }
+              if (type != arrayType.get(0)) {
+                allTypesConsistent[0] = false;
+              }
+            });
 
     if (!allTypesConsistent[0]) {
       return null;
@@ -193,22 +193,22 @@ public class JsonToMapUtils {
 
   public static Struct addToStruct(ObjectNode node, Schema schema, Struct struct) {
     schema
-            .fields()
-            .forEach(
-                    field -> {
-                      JsonNode element = node.get(field.name());
-                      Schema.Type targetType = field.schema().type();
-                      if (targetType == Schema.Type.ARRAY) {
-                        struct.put(
-                                field.name(),
-                                populateArray(
-                                        element, field.schema().valueSchema(), field.name(), Lists.newArrayList()));
-                      } else if (targetType == Schema.Type.MAP) {
-                        struct.put(field.name(), populateMap(element, Maps.newHashMap()));
-                      } else {
-                        struct.put(field.name(), extractSimpleValue(element, targetType, field.name()));
-                      }
-                    });
+        .fields()
+        .forEach(
+            field -> {
+              JsonNode element = node.get(field.name());
+              Schema.Type targetType = field.schema().type();
+              if (targetType == Schema.Type.ARRAY) {
+                struct.put(
+                    field.name(),
+                    populateArray(
+                        element, field.schema().valueSchema(), field.name(), Lists.newArrayList()));
+              } else if (targetType == Schema.Type.MAP) {
+                struct.put(field.name(), populateMap(element, Maps.newHashMap()));
+              } else {
+                struct.put(field.name(), extractSimpleValue(element, targetType, field.name()));
+              }
+            });
     return struct;
   }
 
@@ -238,18 +238,18 @@ public class JsonToMapUtils {
           obj = node.binaryValue();
         } catch (Exception e) {
           throw new RuntimeException(
-                  String.format("parsing binary value threw exception for %s", fieldName), e);
+              String.format("parsing binary value threw exception for %s", fieldName), e);
         }
         break;
       default:
         throw new RuntimeException(
-                String.format("Unexpected type %s for field %s", type, fieldName));
+            String.format("Unexpected type %s for field %s", type, fieldName));
     }
     return obj;
   }
 
   private static List<Object> populateArray(
-          JsonNode node, Schema schema, String fieldName, List<Object> acc) {
+      JsonNode node, Schema schema, String fieldName, List<Object> acc) {
     if (schema.type() == Schema.Type.ARRAY) {
       for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
         JsonNode arrayNode = it.next();
@@ -258,15 +258,13 @@ public class JsonToMapUtils {
       }
     } else {
       node.elements()
-              .forEachRemaining(
-                      arrayEntry -> acc.add(extractSimpleValue(arrayEntry, schema.type(), fieldName)));
+          .forEachRemaining(
+              arrayEntry -> acc.add(extractSimpleValue(arrayEntry, schema.type(), fieldName)));
     }
     return acc;
   }
 
-  public static HashMap<String, String> populateMap(
-          JsonNode node, HashMap<String, String> map
-  ) {
+  public static Map<String, String> populateMap(JsonNode node, Map<String, String> map) {
     for (Iterator<Map.Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
       Map.Entry<String, JsonNode> element = it.next();
       map.put(element.getKey(), nodeToText(element.getValue()));

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
@@ -1,0 +1,201 @@
+package io.tabular.iceberg.connect.transforms;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.*;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class JsonToMapUtils {
+    private static final Map<Class<? extends JsonNode>, Schema> JSON_NODE_TO_SCHEMA = getJsonNodeToSchema();
+    private static Map<Class<? extends JsonNode>, Schema> getJsonNodeToSchema() {
+        final Map<Class<? extends JsonNode>, Schema> map = Maps.newHashMap();
+        map.put(BinaryNode.class, Schema.OPTIONAL_BYTES_SCHEMA);
+        map.put(BooleanNode.class, Schema.OPTIONAL_BOOLEAN_SCHEMA);
+        map.put(TextNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        map.put(IntNode.class, Schema.OPTIONAL_INT32_SCHEMA);
+        map.put(LongNode.class, Schema.OPTIONAL_INT64_SCHEMA);
+        map.put(FloatNode.class, Schema.OPTIONAL_FLOAT32_SCHEMA);
+        map.put(DoubleNode.class, Schema.OPTIONAL_FLOAT64_SCHEMA);
+        map.put(ArrayNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        map.put(ObjectNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        map.put(BigIntegerNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        map.put(DecimalNode.class, Schema.OPTIONAL_STRING_SCHEMA);
+        return ImmutableMap.copyOf(map);
+    }
+    public static void addToSchema(String fieldName, Schema schema, SchemaBuilder builder) {
+        if (schema != null) {
+            builder.field(fieldName, schema);
+        }
+    }
+
+    public static SchemaBuilder addFieldSchemaBuilder(Map.Entry<String, JsonNode> kv, SchemaBuilder builder) {
+        String key = kv.getKey();
+        JsonNode value = kv.getValue();
+        addToSchema(key, schemaFromNode(value), builder);
+        return builder;
+    }
+
+    public static Schema schemaFromNode(JsonNode node) {
+        if (!node.isNull() && !node.isMissingNode()) {
+            if (node.isArray()) {
+                ArrayNode array = (ArrayNode) node;
+                // can't create a schema for an empty array since the inner type is not known.
+                if (!array.isEmpty()) {
+                    Class<? extends JsonNode> arrayType = arrayNodeType(array);
+                    if (arrayType != null) {
+                        if (arrayType != NullNode.class && arrayType != MissingNode.class) {
+                            if (arrayType == ObjectNode.class) {
+                                // arrays of objects become strings
+                                int objectCount = 0;
+                                int emptyObjectCount = 0;
+                                for (Iterator<JsonNode> it = array.elements(); it.hasNext(); ) {
+                                    JsonNode element = it.next();
+                                    objectCount += 1;
+                                    if (!element.elements().hasNext()) {
+                                       emptyObjectCount += 1;
+                                    }
+                                }
+                                if (objectCount == emptyObjectCount) {
+                                    return null;
+                                } else {
+                                    return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+                                }
+                            } else if (arrayType == ArrayNode.class) {
+                                // nested array case
+                                // need to protect against arrays of empty arrays, arrays of empty objects, arrays inconsistent types, etc.
+                                List<Schema> nestedSchemas = Lists.newArrayList();
+                                boolean[] hasValidSchema = {true};
+                                node.elements().forEachRemaining(nodeElement -> {
+                                    Schema nestedElementSchema = schemaFromNode(nodeElement);
+                                    if (nestedElementSchema == null) {
+                                        hasValidSchema[0] = false;
+                                    }
+                                    nestedSchemas.add(nestedElementSchema);
+                                });
+                                if (!nestedSchemas.isEmpty() && hasValidSchema[0]) {
+                                    boolean allMatch = nestedSchemas.stream().allMatch(schema -> schema.equals(nestedSchemas.get(0)));
+                                    if (allMatch) {
+                                        return SchemaBuilder.array(nestedSchemas.get(0)).optional().build();
+                                    } else {
+                                        return SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build()).optional().build();
+                                    }
+                                } else {
+                                    return null;
+                                }
+                            } else {
+
+                                // if we are a consistent primitive
+                                return SchemaBuilder.array(JSON_NODE_TO_SCHEMA.get(arrayType)).optional().build();
+                            }
+                        }
+                    } else {
+                        // if types of the array are inconsistent, convert to a string
+                        return SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+                    }
+                }
+            } else if (node.isObject()) {
+                if (node.elements().hasNext()) {
+                    return JSON_NODE_TO_SCHEMA.get(node.getClass());
+                }
+            } else {
+                return JSON_NODE_TO_SCHEMA.get(node.getClass());
+            }
+        }
+        return null;
+    }
+
+    /* Kafka Connect arrays must all be the same type */
+    public static Class<? extends JsonNode> arrayNodeType(ArrayNode array) {
+        final List<Class<? extends JsonNode>> arrayType = Lists.newArrayList();
+        arrayType.add(null);
+        final boolean[] allTypesConsistent = {true};
+        // breaks on number.
+        array.elements().forEachRemaining(node -> {
+            Class<? extends JsonNode> type = node.getClass();
+            if (arrayType.get(0) == null) {
+                arrayType.set(0,type);
+            }
+            if (type != arrayType.get(0)) {
+                allTypesConsistent[0] = false;
+            }
+        });
+
+        if (!allTypesConsistent[0]) {
+            return null;
+        }
+
+        return arrayType.get(0);
+    }
+    public static Struct addToStruct(ObjectNode node, Schema schema, Struct struct) {
+        schema.fields().forEach(field -> {
+            JsonNode element = node.get(field.name());
+            Schema.Type targetType = field.schema().type();
+            if (targetType == Schema.Type.ARRAY) {
+                struct.put(field.name(), populateArray(element, field.schema().valueSchema(), field.name(), Lists.newArrayList()));
+            } else {
+                struct.put(field.name(), extractSimpleValue(element, targetType, field.name()));
+            }
+        });
+        return struct;
+    }
+
+    public static Object extractSimpleValue(JsonNode node, Schema.Type type, String fieldName) {
+        Object obj;
+        switch (type) {
+            case STRING:
+                if (node.isTextual()) {
+                    obj = node.textValue();
+                } else {
+                    obj = node.toString();
+                }
+                break;
+            case BOOLEAN:
+                obj = node.booleanValue();
+                break;
+            case INT32:
+                obj = node.intValue();
+                break;
+            case INT64:
+                obj = node.longValue();
+                break;
+            case FLOAT32:
+                obj = node.floatValue();
+                break;
+            case FLOAT64:
+                obj = node.doubleValue();
+                break;
+            case BYTES:
+                try {
+                    obj = node.binaryValue();
+                } catch (Exception e) {
+                    throw new RuntimeException(String.format("parsing binary value threw exception for %s", fieldName), e);
+                }
+                break;
+            default:
+                throw new RuntimeException(String.format("Unexpected type %s for field %s", type, fieldName));
+        }
+        return obj;
+    }
+
+    private static List<Object> populateArray(JsonNode node, Schema schema, String fieldName, List<Object> acc) {
+        if (schema.type() == Schema.Type.ARRAY) {
+            for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
+                JsonNode arrayNode = it.next();
+                List<Object> nestedList = Lists.newArrayList();
+                acc.add(populateArray(arrayNode, schema.valueSchema(), fieldName, nestedList));
+            }
+        } else {
+            node.elements().forEachRemaining(arrayEntry -> acc.add(extractSimpleValue(arrayEntry, schema.type(), fieldName)));
+        }
+        return acc;
+    }
+}

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/JsonToMapUtils.java
@@ -101,16 +101,12 @@ class JsonToMapUtils {
     return ImmutableMap.copyOf(map);
   }
 
-  public static void addToSchema(String fieldName, Schema schema, SchemaBuilder builder) {
-    if (schema != null) {
-      builder.field(fieldName, schema);
-    }
-  }
-
   public static void addField(Map.Entry<String, JsonNode> kv, SchemaBuilder builder) {
     String key = kv.getKey();
-    JsonNode value = kv.getValue();
-    addToSchema(key, schemaFromNode(value), builder);
+    Schema schema = schemaFromNode(kv.getValue());
+    if (schema != null) {
+      builder.field(key, schema);
+    }
   }
 
   public static Schema schemaFromNode(JsonNode node) {

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/FileLoads.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/FileLoads.java
@@ -1,0 +1,15 @@
+package io.tabular.iceberg.connect.transforms;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public abstract class FileLoads {
+    protected final String getFile(String fileName) throws IOException, URISyntaxException {
+        URL jsonResource = getClass().getClassLoader().getResource(fileName);
+        return new String(Files.readAllBytes(Paths.get(jsonResource.toURI())), StandardCharsets.UTF_8);
+    }
+}

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/FileLoads.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/FileLoads.java
@@ -26,8 +26,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public abstract class FileLoads {
-  protected final String getFile(String fileName) throws IOException, URISyntaxException {
-    URL jsonResource = getClass().getClassLoader().getResource(fileName);
+  protected static final String getFile(String fileName) throws IOException, URISyntaxException {
+    URL jsonResource = FileLoads.class.getClassLoader().getResource(fileName);
     return new String(Files.readAllBytes(Paths.get(jsonResource.toURI())), StandardCharsets.UTF_8);
   }
 }

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/FileLoads.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/FileLoads.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.tabular.iceberg.connect.transforms;
 
 import java.io.IOException;
@@ -8,8 +26,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public abstract class FileLoads {
-    protected final String getFile(String fileName) throws IOException, URISyntaxException {
-        URL jsonResource = getClass().getClassLoader().getResource(fileName);
-        return new String(Files.readAllBytes(Paths.get(jsonResource.toURI())), StandardCharsets.UTF_8);
-    }
+  protected final String getFile(String fileName) throws IOException, URISyntaxException {
+    URL jsonResource = getClass().getClassLoader().getResource(fileName);
+    return new String(Files.readAllBytes(Paths.get(jsonResource.toURI())), StandardCharsets.UTF_8);
+  }
 }

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.common.record.TimestampType;
@@ -31,8 +32,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 public class JsonToMapTransformTest extends FileLoads {
 
@@ -55,7 +54,6 @@ public class JsonToMapTransformTest extends FileLoads {
   @DisplayName("should return null records as-is")
   public void nullRecords() {
     try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
-      smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "0"));
       SinkRecord record =
           new SinkRecord(
               topic,
@@ -74,7 +72,7 @@ public class JsonToMapTransformTest extends FileLoads {
 
   @Test
   @DisplayName("should throw exception if the value is not a json object")
-  public void shouldThrowExceptionNonJsonObjects() throws Exception {
+  public void shouldThrowExceptionNonJsonObjects() {
     try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
       SinkRecord record =
           new SinkRecord(
@@ -115,7 +113,7 @@ public class JsonToMapTransformTest extends FileLoads {
       "should contain a single value of Map<String,String> if configured to convert root node")
   public void singleValueOnRootNode() {
     try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
-      smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "0"));
+      smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "true"));
       SinkRecord record =
           new SinkRecord(
               topic,
@@ -128,7 +126,12 @@ public class JsonToMapTransformTest extends FileLoads {
               timestamp,
               TimestampType.CREATE_TIME);
       SinkRecord result = smt.apply(record);
-      Schema expectedSchema = SchemaBuilder.struct().field("payload", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build()).build();
+      Schema expectedSchema =
+          SchemaBuilder.struct()
+              .field(
+                  "payload",
+                  SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build())
+              .build();
       assertInstanceOf(Struct.class, result.value());
       Struct resultStruct = (Struct) result.value();
 

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -85,7 +85,7 @@ public class JsonToMapTransformTest extends FileLoads {
               offset,
               timestamp,
               TimestampType.CREATE_TIME);
-      assertThrows(RuntimeException.class, () -> smt.apply(record));
+      assertThrows(JsonToMapException.class, () -> smt.apply(record));
     }
   }
 
@@ -104,7 +104,7 @@ public class JsonToMapTransformTest extends FileLoads {
               offset,
               timestamp,
               TimestampType.CREATE_TIME);
-      assertThrows(RuntimeException.class, () -> smt.apply(record));
+      assertThrows(JsonToMapException.class, () -> smt.apply(record));
     }
   }
 

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -30,6 +31,8 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 public class JsonToMapTransformTest extends FileLoads {
 
@@ -125,11 +128,14 @@ public class JsonToMapTransformTest extends FileLoads {
               timestamp,
               TimestampType.CREATE_TIME);
       SinkRecord result = smt.apply(record);
-      Schema expectedSchema = SchemaBuilder.struct().field("payload", Schema.STRING_SCHEMA).build();
-      Struct expecedStruct = new Struct(expectedSchema).put("payload", "{\"key\":1,\"a\":\"a\"}");
+      Schema expectedSchema = SchemaBuilder.struct().field("payload", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build()).build();
       assertInstanceOf(Struct.class, result.value());
       Struct resultStruct = (Struct) result.value();
-      assertThat(resultStruct.get("payload")).isEqualTo("{\"key\":1,\"a\":\"a\"}");
+
+      Map<String, String> expectedValue = Maps.newHashMap();
+      expectedValue.put("key", "1");
+      expectedValue.put("a", "a");
+      assertThat(resultStruct.get("payload")).isEqualTo(expectedValue);
       assertThat(result.valueSchema()).isEqualTo(expectedSchema);
     }
   }

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -161,7 +161,7 @@ public class JsonToMapTransformTest extends FileLoads {
       SinkRecord result = smt.apply(record);
       assertInstanceOf(Struct.class, result.value());
       Struct resultStruct = (Struct) result.value();
-      assertThat(resultStruct.schema().fields().size()).isEqualTo(18);
+      assertThat(resultStruct.schema().fields().size()).isEqualTo(19);
       assertThat(resultStruct.get("string")).isEqualTo("string");
     }
   }

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -1,4 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.tabular.iceberg.connect.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.common.record.TimestampType;
@@ -9,83 +31,129 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 public class JsonToMapTransformTest extends FileLoads {
 
-    private String loadJson() {
-        try {
-            return getFile("jsonmap.json");
-        } catch (Exception e) {
-            throw new RuntimeException("failed to load jsonmap.json in test", e);
-        }
+  private String loadJson() {
+    try {
+      return getFile("jsonmap.json");
+    } catch (Exception e) {
+      throw new RuntimeException("failed to load jsonmap.json in test", e);
     }
+  }
 
+  private final String topic = "topic";
+  private final int partition = 0;
+  private final Long offset = 100L;
+  private final Long timestamp = 1000L;
+  private final String keyValue = "key_value:";
+  private final Schema keySchema = SchemaBuilder.STRING_SCHEMA;
 
-    private final String TOPIC = "topic";
-    private final int PARTITION = 0;
-    private final Long OFFSET = 100L;
-    private final Long TIMESTAMP = 1000L;
-    private final String KEY_VALUE = "key_value:";
-    private final Schema KEY_SCHEMA = SchemaBuilder.STRING_SCHEMA;
-
-    @Test
-    @DisplayName("should return null records as-is")
-    public void nullRecords() {
-        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
-            smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "0"));
-            SinkRecord record = new SinkRecord(TOPIC, PARTITION, null, null, null, null, OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
-            SinkRecord result = smt.apply(record);
-            assertThat(result).isSameAs(record);
-        }
+  @Test
+  @DisplayName("should return null records as-is")
+  public void nullRecords() {
+    try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+      smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "0"));
+      SinkRecord record =
+          new SinkRecord(
+              topic,
+              partition,
+              null,
+              null,
+              null,
+              null,
+              offset,
+              timestamp,
+              TimestampType.CREATE_TIME);
+      SinkRecord result = smt.apply(record);
+      assertThat(result).isSameAs(record);
     }
+  }
 
+  @Test
+  @DisplayName("should throw exception if the value is not a json object")
+  public void shouldThrowExceptionNonJsonObjects() throws Exception {
+    try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+      SinkRecord record =
+          new SinkRecord(
+              topic,
+              partition,
+              keySchema,
+              keyValue,
+              null,
+              "not_a_json_object",
+              offset,
+              timestamp,
+              TimestampType.CREATE_TIME);
+      assertThrows(RuntimeException.class, () -> smt.apply(record));
+    }
+  }
 
-    @Test
-    @DisplayName("should throw exception if the value is not a json object")
-    public void shouldThrowExceptionNonJsonObjects() throws Exception {
-        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
-            SinkRecord record = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY_VALUE, null, "not_a_json_object", OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
-            assertThrows(RuntimeException.class, () -> smt.apply(record));
-        }
+  @Test
+  @DisplayName("should throw exception if not valid json")
+  public void shouldThrowExceptionInvalidJson() {
+    try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+      SinkRecord record =
+          new SinkRecord(
+              topic,
+              partition,
+              keySchema,
+              keyValue,
+              null,
+              "{\"key\": 1,\"\"\"***",
+              offset,
+              timestamp,
+              TimestampType.CREATE_TIME);
+      assertThrows(RuntimeException.class, () -> smt.apply(record));
     }
-    @Test
-    @DisplayName("should throw exception if not valid json")
-    public void shouldThrowExceptionInvalidJson() {
-        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
-            SinkRecord record = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY_VALUE, null, "{\"key\": 1,\"\"\"***", OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
-            assertThrows(RuntimeException.class, () -> smt.apply(record));
-        }
-    }
+  }
 
-    @Test
-    @DisplayName("should contain a single value of Map<String,String> if configured to convert root node")
-    public void singleValueOnRootNode() {
-        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
-            smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "0"));
-            SinkRecord record = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY_VALUE, null, "{\"key\":1,\"a\":\"a\"}", OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
-            SinkRecord result = smt.apply(record);
-            Schema expectedSchema = SchemaBuilder.struct().field("payload", Schema.STRING_SCHEMA).build();
-            Struct expecedStruct = new Struct(expectedSchema).put("payload", "{\"key\":1,\"a\":\"a\"}" );
-            assertInstanceOf(Struct.class, result.value());
-            Struct resultStruct = (Struct) result.value();
-            assertThat(resultStruct.get("payload")).isEqualTo("{\"key\":1,\"a\":\"a\"}");
-            assertThat(result.valueSchema()).isEqualTo(expectedSchema);
-        }
+  @Test
+  @DisplayName(
+      "should contain a single value of Map<String,String> if configured to convert root node")
+  public void singleValueOnRootNode() {
+    try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+      smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "0"));
+      SinkRecord record =
+          new SinkRecord(
+              topic,
+              partition,
+              keySchema,
+              keyValue,
+              null,
+              "{\"key\":1,\"a\":\"a\"}",
+              offset,
+              timestamp,
+              TimestampType.CREATE_TIME);
+      SinkRecord result = smt.apply(record);
+      Schema expectedSchema = SchemaBuilder.struct().field("payload", Schema.STRING_SCHEMA).build();
+      Struct expecedStruct = new Struct(expectedSchema).put("payload", "{\"key\":1,\"a\":\"a\"}");
+      assertInstanceOf(Struct.class, result.value());
+      Struct resultStruct = (Struct) result.value();
+      assertThat(resultStruct.get("payload")).isEqualTo("{\"key\":1,\"a\":\"a\"}");
+      assertThat(result.valueSchema()).isEqualTo(expectedSchema);
     }
+  }
 
-    @Test
-    @DisplayName("should contain a struct on the value if configured to convert after root node")
-    public void structOnRootNode() {
-        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
-            SinkRecord record = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY_VALUE, null, loadJson(), OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
-            SinkRecord result = smt.apply(record);
-            assertInstanceOf(Struct.class, result.value());
-            Struct resultStruct = (Struct) result.value();
-            assertThat(resultStruct.schema().fields().size()).isEqualTo(16);
-            assertThat(resultStruct.get("string")).isEqualTo("string");
-        }
+  @Test
+  @DisplayName("should contain a struct on the value if configured to convert after root node")
+  public void structOnRootNode() {
+    try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+      SinkRecord record =
+          new SinkRecord(
+              topic,
+              partition,
+              keySchema,
+              keyValue,
+              null,
+              loadJson(),
+              offset,
+              timestamp,
+              TimestampType.CREATE_TIME);
+      SinkRecord result = smt.apply(record);
+      assertInstanceOf(Struct.class, result.value());
+      Struct resultStruct = (Struct) result.value();
+      assertThat(resultStruct.schema().fields().size()).isEqualTo(16);
+      assertThat(resultStruct.get("string")).isEqualTo("string");
     }
+  }
 }

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -161,7 +161,7 @@ public class JsonToMapTransformTest extends FileLoads {
       SinkRecord result = smt.apply(record);
       assertInstanceOf(Struct.class, result.value());
       Struct resultStruct = (Struct) result.value();
-      assertThat(resultStruct.schema().fields().size()).isEqualTo(16);
+      assertThat(resultStruct.schema().fields().size()).isEqualTo(18);
       assertThat(resultStruct.get("string")).isEqualTo("string");
     }
   }

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -1,0 +1,91 @@
+package io.tabular.iceberg.connect.transforms;
+
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JsonToMapTransformTest extends FileLoads {
+
+    private String loadJson() {
+        try {
+            return getFile("jsonmap.json");
+        } catch (Exception e) {
+            throw new RuntimeException("failed to load jsonmap.json in test", e);
+        }
+    }
+
+
+    private final String TOPIC = "topic";
+    private final int PARTITION = 0;
+    private final Long OFFSET = 100L;
+    private final Long TIMESTAMP = 1000L;
+    private final String KEY_VALUE = "key_value:";
+    private final Schema KEY_SCHEMA = SchemaBuilder.STRING_SCHEMA;
+
+    @Test
+    @DisplayName("should return null records as-is")
+    public void nullRecords() {
+        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+            smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "0"));
+            SinkRecord record = new SinkRecord(TOPIC, PARTITION, null, null, null, null, OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
+            SinkRecord result = smt.apply(record);
+            assertThat(result).isSameAs(record);
+        }
+    }
+
+
+    @Test
+    @DisplayName("should throw exception if the value is not a json object")
+    public void shouldThrowExceptionNonJsonObjects() throws Exception {
+        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+            SinkRecord record = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY_VALUE, null, "not_a_json_object", OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
+            assertThrows(RuntimeException.class, () -> smt.apply(record));
+        }
+    }
+    @Test
+    @DisplayName("should throw exception if not valid json")
+    public void shouldThrowExceptionInvalidJson() {
+        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+            SinkRecord record = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY_VALUE, null, "{\"key\": 1,\"\"\"***", OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
+            assertThrows(RuntimeException.class, () -> smt.apply(record));
+        }
+    }
+
+    @Test
+    @DisplayName("should contain a single value of Map<String,String> if configured to convert root node")
+    public void singleValueOnRootNode() {
+        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+            smt.configure(ImmutableMap.of(JsonToMapTransform.JSON_LEVEL, "0"));
+            SinkRecord record = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY_VALUE, null, "{\"key\":1,\"a\":\"a\"}", OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
+            SinkRecord result = smt.apply(record);
+            Schema expectedSchema = SchemaBuilder.struct().field("payload", Schema.STRING_SCHEMA).build();
+            Struct expecedStruct = new Struct(expectedSchema).put("payload", "{\"key\":1,\"a\":\"a\"}" );
+            assertInstanceOf(Struct.class, result.value());
+            Struct resultStruct = (Struct) result.value();
+            assertThat(resultStruct.get("payload")).isEqualTo("{\"key\":1,\"a\":\"a\"}");
+            assertThat(result.valueSchema()).isEqualTo(expectedSchema);
+        }
+    }
+
+    @Test
+    @DisplayName("should contain a struct on the value if configured to convert after root node")
+    public void structOnRootNode() {
+        try (JsonToMapTransform<SinkRecord> smt = new JsonToMapTransform<>()) {
+            SinkRecord record = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY_VALUE, null, loadJson(), OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
+            SinkRecord result = smt.apply(record);
+            assertInstanceOf(Struct.class, result.value());
+            Struct resultStruct = (Struct) result.value();
+            assertThat(resultStruct.schema().fields().size()).isEqualTo(16);
+            assertThat(resultStruct.get("string")).isEqualTo("string");
+        }
+    }
+}

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -1,8 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.tabular.iceberg.connect.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.*;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Base64;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -11,257 +41,284 @@ import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Base64;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-
 class JsonToMapUtilsTest extends FileLoads {
-    private final ObjectMapper mapper = new ObjectMapper();
+  private final ObjectMapper mapper = new ObjectMapper();
 
-    private final ObjectNode objNode = loadJson(mapper);
+  private final ObjectNode objNode = loadJson(mapper);
 
-    private ObjectNode loadJson(ObjectMapper mapper) {
-        try {
-            return (ObjectNode) mapper.readTree(getFile("jsonmap.json"));
-        } catch (Exception e) {
-            throw new RuntimeException("failed to load jsonmap.json in test", e);
-        }
+  private ObjectNode loadJson(ObjectMapper objectMapper) {
+    try {
+      return (ObjectNode) objectMapper.readTree(getFile("jsonmap.json"));
+    } catch (Exception e) {
+      throw new RuntimeException("failed to load jsonmap.json in test", e);
     }
+  }
 
-    @Test
-    @DisplayName("addToSchema should add schemas to builder unless schema is null")
-    public void addToSchema() {
-        SchemaBuilder builder = SchemaBuilder.struct();
-        JsonToMapUtils.addToSchema("good", Schema.STRING_SCHEMA, builder);
-        JsonToMapUtils.addToSchema("null", null, builder);
-        Schema result = builder.build();
-        assertThat(result.fields()).isEqualTo(Lists.newArrayList(new Field("good", 0, Schema.STRING_SCHEMA)));
-    }
+  @Test
+  @DisplayName("addToSchema should add schemas to builder unless schema is null")
+  public void addToSchema() {
+    SchemaBuilder builder = SchemaBuilder.struct();
+    JsonToMapUtils.addToSchema("good", Schema.STRING_SCHEMA, builder);
+    JsonToMapUtils.addToSchema("null", null, builder);
+    Schema result = builder.build();
+    assertThat(result.fields())
+        .isEqualTo(Lists.newArrayList(new Field("good", 0, Schema.STRING_SCHEMA)));
+  }
 
-    @Test
-    @DisplayName("extractSimpleValue extracts type from Node based on Schema")
-    public void primitiveBasedOnSchemaHappyPath() {
-        JsonNode stringNode = objNode.get("string");
-        JsonNode booleanNode = objNode.get("boolean");
-        JsonNode intNode = objNode.get("int");
-        JsonNode longNode = objNode.get("long");
-        JsonNode floatIsDoubleNode = objNode.get("float_is_double");
-        JsonNode doubleNode = objNode.get("double");
-        JsonNode bytesNode = objNode.get("bytes");
+  @Test
+  @DisplayName("extractSimpleValue extracts type from Node based on Schema")
+  public void primitiveBasedOnSchemaHappyPath() {
+    JsonNode stringNode = objNode.get("string");
+    JsonNode booleanNode = objNode.get("boolean");
+    JsonNode intNode = objNode.get("int");
+    JsonNode longNode = objNode.get("long");
+    JsonNode floatIsDoubleNode = objNode.get("float_is_double");
+    JsonNode doubleNode = objNode.get("double");
+    JsonNode bytesNode = objNode.get("bytes");
 
-        assertThat(JsonToMapUtils.extractSimpleValue(stringNode, Schema.Type.STRING, "")).isEqualTo("string");
-        assertThat(JsonToMapUtils.extractSimpleValue(booleanNode, Schema.Type.BOOLEAN, "")).isEqualTo(true);
-        assertThat(JsonToMapUtils.extractSimpleValue(intNode, Schema.Type.INT32, "")).isEqualTo(42);
-        assertThat(JsonToMapUtils.extractSimpleValue(longNode, Schema.Type.INT64,"")).isEqualTo(3147483647L);
-        assertThat(JsonToMapUtils.extractSimpleValue(floatIsDoubleNode, Schema.Type.FLOAT64, "")).isEqualTo(3.0);
-        assertThat(JsonToMapUtils.extractSimpleValue(doubleNode, Schema.Type.FLOAT64, "")).isEqualTo( 0.3);
-        byte[] byteResult = (byte[]) JsonToMapUtils.extractSimpleValue(bytesNode, Schema.Type.BYTES, "");
-        assertArrayEquals(byteResult, Base64.getDecoder().decode("SGVsbG8="));
-    }
+    assertThat(JsonToMapUtils.extractSimpleValue(stringNode, Schema.Type.STRING, ""))
+        .isEqualTo("string");
+    assertThat(JsonToMapUtils.extractSimpleValue(booleanNode, Schema.Type.BOOLEAN, ""))
+        .isEqualTo(true);
+    assertThat(JsonToMapUtils.extractSimpleValue(intNode, Schema.Type.INT32, "")).isEqualTo(42);
+    assertThat(JsonToMapUtils.extractSimpleValue(longNode, Schema.Type.INT64, ""))
+        .isEqualTo(3147483647L);
+    assertThat(JsonToMapUtils.extractSimpleValue(floatIsDoubleNode, Schema.Type.FLOAT64, ""))
+        .isEqualTo(3.0);
+    assertThat(JsonToMapUtils.extractSimpleValue(doubleNode, Schema.Type.FLOAT64, ""))
+        .isEqualTo(0.3);
+    byte[] byteResult =
+        (byte[]) JsonToMapUtils.extractSimpleValue(bytesNode, Schema.Type.BYTES, "");
+    assertArrayEquals(byteResult, Base64.getDecoder().decode("SGVsbG8="));
+  }
 
-    @Test
-    @DisplayName("extractSimpleValue converts complex nodes to strings if schema is string")
-    public void exactStringsFromComplexNodes() {
-        JsonNode arrayObjects = objNode.get("array_objects");
-        assertInstanceOf(ArrayNode.class, arrayObjects);
+  @Test
+  @DisplayName("extractSimpleValue converts complex nodes to strings if schema is string")
+  public void exactStringsFromComplexNodes() {
+    JsonNode arrayObjects = objNode.get("array_objects");
+    assertInstanceOf(ArrayNode.class, arrayObjects);
 
-        JsonNode nestedObjNode = objNode.get("nested_obj");
-        assertInstanceOf(ObjectNode.class, nestedObjNode);
+    JsonNode nestedObjNode = objNode.get("nested_obj");
+    assertInstanceOf(ObjectNode.class, nestedObjNode);
 
-        JsonNode arrayDifferentTypes = objNode.get("array_different_types");
-        assertInstanceOf(ArrayNode.class, arrayDifferentTypes);
+    JsonNode arrayDifferentTypes = objNode.get("array_different_types");
+    assertInstanceOf(ArrayNode.class, arrayDifferentTypes);
 
-        JsonNode bigInt = objNode.get("bigInt");
-        assertInstanceOf(BigIntegerNode.class, bigInt);
+    JsonNode bigInt = objNode.get("bigInt");
+    assertInstanceOf(BigIntegerNode.class, bigInt);
 
-        assertThat(JsonToMapUtils.extractSimpleValue(arrayObjects, Schema.Type.STRING, "")).isEqualTo("[{\"key\":1}]");
-        assertThat(JsonToMapUtils.extractSimpleValue(nestedObjNode, Schema.Type.STRING, "")).isEqualTo("{\"one\":1}");
-        assertThat(JsonToMapUtils.extractSimpleValue(arrayDifferentTypes, Schema.Type.STRING, "")).isEqualTo("[\"one\",1]");
-        assertThat(JsonToMapUtils.extractSimpleValue(bigInt, Schema.Type.STRING, "")).isEqualTo("354736184430273859332531123456");
-    }
+    assertThat(JsonToMapUtils.extractSimpleValue(arrayObjects, Schema.Type.STRING, ""))
+        .isEqualTo("[{\"key\":1}]");
+    assertThat(JsonToMapUtils.extractSimpleValue(nestedObjNode, Schema.Type.STRING, ""))
+        .isEqualTo("{\"one\":1}");
+    assertThat(JsonToMapUtils.extractSimpleValue(arrayDifferentTypes, Schema.Type.STRING, ""))
+        .isEqualTo("[\"one\",1]");
+    assertThat(JsonToMapUtils.extractSimpleValue(bigInt, Schema.Type.STRING, ""))
+        .isEqualTo("354736184430273859332531123456");
+  }
 
-    @Test
-    @DisplayName("extractSimpleValue throws for non-primitive schema types")
-    public void primitiveBasedOnSchemaThrows() {
-        assertThrows(RuntimeException.class, () -> JsonToMapUtils.extractSimpleValue(objNode.get("string"), Schema.Type.STRUCT, ""));
-    }
+  @Test
+  @DisplayName("extractSimpleValue throws for non-primitive schema types")
+  public void primitiveBasedOnSchemaThrows() {
+    assertThrows(
+        RuntimeException.class,
+        () -> JsonToMapUtils.extractSimpleValue(objNode.get("string"), Schema.Type.STRUCT, ""));
+  }
 
-    @Test
-    @DisplayName("arrayNodeType returns a type if all elements of the array are the same type")
-    public void determineArrayNodeType() {
-        ArrayNode arrayInt = (ArrayNode) objNode.get("array_int");
-        ArrayNode arrayArrayInt = (ArrayNode) objNode.get("array_array_int");
-        assertThat(IntNode.class).isEqualTo(JsonToMapUtils.arrayNodeType(arrayInt));
-        assertThat(ArrayNode.class).isEqualTo(JsonToMapUtils.arrayNodeType(arrayArrayInt));
-    }
+  @Test
+  @DisplayName("arrayNodeType returns a type if all elements of the array are the same type")
+  public void determineArrayNodeType() {
+    ArrayNode arrayInt = (ArrayNode) objNode.get("array_int");
+    ArrayNode arrayArrayInt = (ArrayNode) objNode.get("array_array_int");
+    assertThat(IntNode.class).isEqualTo(JsonToMapUtils.arrayNodeType(arrayInt));
+    assertThat(ArrayNode.class).isEqualTo(JsonToMapUtils.arrayNodeType(arrayArrayInt));
+  }
 
-    @Test
-    @DisplayName("arrayNodeType returns null if elements of the array are different types")
-    public void determineArrayNodeTypeNotSameTypes() {
-        ArrayNode mixedArray = (ArrayNode) objNode.get("array_different_types");
-        assertThat(JsonToMapUtils.arrayNodeType(mixedArray)).isNull();
-    }
+  @Test
+  @DisplayName("arrayNodeType returns null if elements of the array are different types")
+  public void determineArrayNodeTypeNotSameTypes() {
+    ArrayNode mixedArray = (ArrayNode) objNode.get("array_different_types");
+    assertThat(JsonToMapUtils.arrayNodeType(mixedArray)).isNull();
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns null for NullNode and MissingNode types")
-    public void schemaFromNodeNullOnNullNodes() {
-        JsonNode nullNode = NullNode.getInstance();
-        JsonNode missingNode = MissingNode.getInstance();
-        assertThat(JsonToMapUtils.schemaFromNode(nullNode)).isNull();
-        assertThat(JsonToMapUtils.schemaFromNode(missingNode)).isNull();
-    }
+  @Test
+  @DisplayName("schemaFromNode returns null for NullNode and MissingNode types")
+  public void schemaFromNodeNullOnNullNodes() {
+    JsonNode nullNode = NullNode.getInstance();
+    JsonNode missingNode = MissingNode.getInstance();
+    assertThat(JsonToMapUtils.schemaFromNode(nullNode)).isNull();
+    assertThat(JsonToMapUtils.schemaFromNode(missingNode)).isNull();
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns String schema for ObjectNodes")
-    public void schemaFromNodeStringsFromObjectNodes() {
-        assertThat(JsonToMapUtils.schemaFromNode(objNode)).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
-    }
+  @Test
+  @DisplayName("schemaFromNode returns String schema for ObjectNodes")
+  public void schemaFromNodeStringsFromObjectNodes() {
+    assertThat(JsonToMapUtils.schemaFromNode(objNode)).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns null for empty ObjectNodes")
-    public void schemaFromNodeNullEmptyObjectNodes() {
-        JsonNode node = objNode.get("empty_obj");
-        assertInstanceOf(ObjectNode.class, node);
-        assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
-    }
+  @Test
+  @DisplayName("schemaFromNode returns null for empty ObjectNodes")
+  public void schemaFromNodeNullEmptyObjectNodes() {
+    JsonNode node = objNode.get("empty_obj");
+    assertInstanceOf(ObjectNode.class, node);
+    assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns String schema for BigInteger nodes")
-    public void schemaFromNodeStringForBigInteger() {
-        JsonNode node = objNode.get("bigInt");
-        assertInstanceOf(BigIntegerNode.class, node);
-        assertThat(JsonToMapUtils.schemaFromNode(node)).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
-    }
+  @Test
+  @DisplayName("schemaFromNode returns String schema for BigInteger nodes")
+  public void schemaFromNodeStringForBigInteger() {
+    JsonNode node = objNode.get("bigInt");
+    assertInstanceOf(BigIntegerNode.class, node);
+    assertThat(JsonToMapUtils.schemaFromNode(node)).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns primitive Schemas for primitive nodes")
-    public void schemaFromNodePrimitiveSchemasFromPrimitiveNodes() {
-        JsonNode intNode = objNode.get("int");
-        JsonNode doubleNode = objNode.get("double");
-        assertInstanceOf(IntNode.class, intNode);
-        assertInstanceOf(DoubleNode.class, doubleNode);
-        assertThat(JsonToMapUtils.schemaFromNode(intNode)).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(JsonToMapUtils.schemaFromNode(doubleNode)).isEqualTo(Schema.OPTIONAL_FLOAT64_SCHEMA);
-    }
+  @Test
+  @DisplayName("schemaFromNode returns primitive Schemas for primitive nodes")
+  public void schemaFromNodePrimitiveSchemasFromPrimitiveNodes() {
+    JsonNode intNode = objNode.get("int");
+    JsonNode doubleNode = objNode.get("double");
+    assertInstanceOf(IntNode.class, intNode);
+    assertInstanceOf(DoubleNode.class, doubleNode);
+    assertThat(JsonToMapUtils.schemaFromNode(intNode)).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+    assertThat(JsonToMapUtils.schemaFromNode(doubleNode)).isEqualTo(Schema.OPTIONAL_FLOAT64_SCHEMA);
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns Array String schema for ArrayNodes with ObjectNode elements")
-    public void schemaFromNodeArrayStringFromArrayObjects() {
-        JsonNode arrayObjects = objNode.get("array_objects");
-        assertInstanceOf(ArrayNode.class, arrayObjects);
-        assertThat(JsonToMapUtils.schemaFromNode(arrayObjects)).isEqualTo(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
-    }
+  @Test
+  @DisplayName("schemaFromNode returns Array String schema for ArrayNodes with ObjectNode elements")
+  public void schemaFromNodeArrayStringFromArrayObjects() {
+    JsonNode arrayObjects = objNode.get("array_objects");
+    assertInstanceOf(ArrayNode.class, arrayObjects);
+    assertThat(JsonToMapUtils.schemaFromNode(arrayObjects))
+        .isEqualTo(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns Array String schema for ArrayNodes with inconsistent types")
-    public void schemaFromNodeArrayStringFromInconsistentArrayNodes() {
-        JsonNode inconsistent = objNode.get("array_different_types");
-        assertInstanceOf(ArrayNode.class, inconsistent);
-        assertThat(JsonToMapUtils.schemaFromNode(inconsistent)).isEqualTo(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
-    }
+  @Test
+  @DisplayName("schemaFromNode returns Array String schema for ArrayNodes with inconsistent types")
+  public void schemaFromNodeArrayStringFromInconsistentArrayNodes() {
+    JsonNode inconsistent = objNode.get("array_different_types");
+    assertInstanceOf(ArrayNode.class, inconsistent);
+    assertThat(JsonToMapUtils.schemaFromNode(inconsistent))
+        .isEqualTo(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns Array[Array[String]] for ArrayNodes of ArrayNodes with inconsistent types")
-    public void schemaFromNodeArraysArrays() {
-        JsonNode node = objNode.get("array_array_inconsistent");
-        assertInstanceOf(ArrayNode.class, node);
+  @Test
+  @DisplayName(
+      "schemaFromNode returns Array[Array[String]] for ArrayNodes of ArrayNodes with inconsistent types")
+  public void schemaFromNodeArraysArrays() {
+    JsonNode node = objNode.get("array_array_inconsistent");
+    assertInstanceOf(ArrayNode.class, node);
 
-        Schema expected = SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build()).optional().build();
-        Schema result = JsonToMapUtils.schemaFromNode(node);
-        assertThat(result).isEqualTo(expected);
-    }
-    @Test
-    @DisplayName("schemaFromNode returns Array[Array[String]] for ArrayNodes of ArrayNodes of objects")
-    public void schemaFromNodeArrayArrayObjects() {
-        JsonNode node = objNode.get("array_array_objects");
-        assertInstanceOf(ArrayNode.class, node);
-        Schema expected = SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build()).optional().build();
-        Schema result = JsonToMapUtils.schemaFromNode(node);
-        assertThat(result).isEqualTo(expected);
-    }
+    Schema expected =
+        SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
+            .optional()
+            .build();
+    Schema result = JsonToMapUtils.schemaFromNode(node);
+    assertThat(result).isEqualTo(expected);
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns Array[Array[Int]] for ArrayNodes of ArrayNodes of IntNode")
-    public void schemaFromNodeArrayArrayOfArrayArrayInt() {
-        JsonNode node = objNode.get("array_array_int");
-        assertInstanceOf(ArrayNode.class, node);
-        Schema expected = SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build()).optional().build();
-        Schema result = JsonToMapUtils.schemaFromNode(node);
-        assertThat(result).isEqualTo(expected);
-    }
+  @Test
+  @DisplayName(
+      "schemaFromNode returns Array[Array[String]] for ArrayNodes of ArrayNodes of objects")
+  public void schemaFromNodeArrayArrayObjects() {
+    JsonNode node = objNode.get("array_array_objects");
+    assertInstanceOf(ArrayNode.class, node);
+    Schema expected =
+        SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
+            .optional()
+            .build();
+    Schema result = JsonToMapUtils.schemaFromNode(node);
+    assertThat(result).isEqualTo(expected);
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns null for empty ArrayNodes")
-    public void schemaFromNodeNullFromEmptyArray() {
-        JsonNode node = objNode.get("empty_arr");
-        assertInstanceOf(ArrayNode.class, node);
-        assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
-    }
-    @Test
-    @DisplayName("schemaFromNode returns null for empty Array of Array nodes")
-    public void schemaFromNodeEmptyArrayOfEmptyArrays() {
-        JsonNode node = objNode.get("empty_arr_arr");
-        assertInstanceOf(ArrayNode.class, node);
-        assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
-    }
+  @Test
+  @DisplayName("schemaFromNode returns Array[Array[Int]] for ArrayNodes of ArrayNodes of IntNode")
+  public void schemaFromNodeArrayArrayOfArrayArrayInt() {
+    JsonNode node = objNode.get("array_array_int");
+    assertInstanceOf(ArrayNode.class, node);
+    Schema expected =
+        SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build())
+            .optional()
+            .build();
+    Schema result = JsonToMapUtils.schemaFromNode(node);
+    assertThat(result).isEqualTo(expected);
+  }
 
-    @Test
-    @DisplayName("schemaFromNode returns null for empty array of empty object")
-    public void schemaFromNodeNullArrayEmptyObject() {
-        JsonNode node = objNode.get("array_empty_object");
-        assertInstanceOf(ArrayNode.class, node);
-        assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
-    }
-    @Test
-    @DisplayName("schemaFromNode returns Array[String] for array of objects even if one object is empty")
-    public void schemaFromNodeMixedObjectsOneEmpty() {
-        JsonNode node = objNode.get("nested_object_contains_empty");
-        assertInstanceOf(ArrayNode.class, node);
-        Schema expected = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
-        Schema result = JsonToMapUtils.schemaFromNode(node);
-        assertThat(result).isEqualTo(expected);
-    }
+  @Test
+  @DisplayName("schemaFromNode returns null for empty ArrayNodes")
+  public void schemaFromNodeNullFromEmptyArray() {
+    JsonNode node = objNode.get("empty_arr");
+    assertInstanceOf(ArrayNode.class, node);
+    assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
+  }
 
-   @Test
-   public void addToStruct() {
-       SchemaBuilder builder = SchemaBuilder.struct();
-       objNode.fields().forEachRemaining(entry -> JsonToMapUtils.addFieldSchemaBuilder(entry, builder));
-       Schema schema = builder.build();
+  @Test
+  @DisplayName("schemaFromNode returns null for empty Array of Array nodes")
+  public void schemaFromNodeEmptyArrayOfEmptyArrays() {
+    JsonNode node = objNode.get("empty_arr_arr");
+    assertInstanceOf(ArrayNode.class, node);
+    assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
+  }
 
-       Struct result = new Struct(schema);
-       JsonToMapUtils.addToStruct(objNode, schema, result);
+  @Test
+  @DisplayName("schemaFromNode returns null for empty array of empty object")
+  public void schemaFromNodeNullArrayEmptyObject() {
+    JsonNode node = objNode.get("array_empty_object");
+    assertInstanceOf(ArrayNode.class, node);
+    assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
+  }
 
-       assertThat(result.get("string")).isEqualTo("string");
-       assertThat(result.get("int")).isEqualTo(42);
-       assertThat(result.get("long")).isEqualTo(3147483647L);
-       assertThat(result.get("boolean")).isEqualTo(true);
-       assertThat(result.get("float_is_double")).isEqualTo(3.0);
-       assertThat(result.get("double")).isEqualTo(0.3);
-       // we don't actually convert to bytes when parsing the json
-       assertThat(result.get("bytes")).isEqualTo("SGVsbG8=");
-       // no way to represent BigInteger in a SinkRecord w/o custom annotations
-       assertThat(result.get("bigInt")).isEqualTo("354736184430273859332531123456");
-       assertThat(result.get("nested_object_contains_empty")).isEqualTo(Lists.newArrayList("{}", "{\"one\":1}"));
-       assertThat(result.get("array_int")).isEqualTo(Lists.newArrayList(1, 1));
-       assertThat(result.get("array_array_int")).isEqualTo(Lists.newArrayList(Lists.newArrayList(1,1), Lists.newArrayList(2,2)));
-       assertThat(result.get("array_objects")).isEqualTo(Lists.newArrayList("{\"key\":1}"));
-       assertThat(result.get("array_array_objects")).isEqualTo(Lists.newArrayList(Lists.newArrayList("{\"key\":1}"), Lists.newArrayList("{\"key\":2}")));
-       assertThat(result.get("array_array_inconsistent")).isEqualTo(Lists.newArrayList(Lists.newArrayList("1"), Lists.newArrayList("2.0")));
-       assertThat(result.get("array_different_types")).isEqualTo(Lists.newArrayList("one", "1"));
-       assertThat(result.get("nested_obj")).isEqualTo("{\"one\":1}");
+  @Test
+  @DisplayName(
+      "schemaFromNode returns Array[String] for array of objects even if one object is empty")
+  public void schemaFromNodeMixedObjectsOneEmpty() {
+    JsonNode node = objNode.get("nested_object_contains_empty");
+    assertInstanceOf(ArrayNode.class, node);
+    Schema expected = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+    Schema result = JsonToMapUtils.schemaFromNode(node);
+    assertThat(result).isEqualTo(expected);
+  }
 
-       // assert empty fields don't show up on the struct
-       assertThrows(RuntimeException.class, () -> result.get("null"));
-       assertThrows(RuntimeException.class, () -> result.get("empty_obj"));
-       assertThrows(RuntimeException.class, () -> result.get("empty_arr"));
-       assertThrows(RuntimeException.class, () -> result.get("empty_arr_arr"));
-       assertThrows(RuntimeException.class, () -> result.get("array_empty_object"));
-   }
+  @Test
+  public void addToStruct() {
+    SchemaBuilder builder = SchemaBuilder.struct();
+    objNode
+        .fields()
+        .forEachRemaining(entry -> JsonToMapUtils.addFieldSchemaBuilder(entry, builder));
+    Schema schema = builder.build();
 
+    Struct result = new Struct(schema);
+    JsonToMapUtils.addToStruct(objNode, schema, result);
+
+    assertThat(result.get("string")).isEqualTo("string");
+    assertThat(result.get("int")).isEqualTo(42);
+    assertThat(result.get("long")).isEqualTo(3147483647L);
+    assertThat(result.get("boolean")).isEqualTo(true);
+    assertThat(result.get("float_is_double")).isEqualTo(3.0);
+    assertThat(result.get("double")).isEqualTo(0.3);
+    // we don't actually convert to bytes when parsing the json
+    assertThat(result.get("bytes")).isEqualTo("SGVsbG8=");
+    // no way to represent BigInteger in a SinkRecord w/o custom annotations
+    assertThat(result.get("bigInt")).isEqualTo("354736184430273859332531123456");
+    assertThat(result.get("nested_object_contains_empty"))
+        .isEqualTo(Lists.newArrayList("{}", "{\"one\":1}"));
+    assertThat(result.get("array_int")).isEqualTo(Lists.newArrayList(1, 1));
+    assertThat(result.get("array_array_int"))
+        .isEqualTo(Lists.newArrayList(Lists.newArrayList(1, 1), Lists.newArrayList(2, 2)));
+    assertThat(result.get("array_objects")).isEqualTo(Lists.newArrayList("{\"key\":1}"));
+    assertThat(result.get("array_array_objects"))
+        .isEqualTo(
+            Lists.newArrayList(
+                Lists.newArrayList("{\"key\":1}"), Lists.newArrayList("{\"key\":2}")));
+    assertThat(result.get("array_array_inconsistent"))
+        .isEqualTo(Lists.newArrayList(Lists.newArrayList("1"), Lists.newArrayList("2.0")));
+    assertThat(result.get("array_different_types")).isEqualTo(Lists.newArrayList("one", "1"));
+    assertThat(result.get("nested_obj")).isEqualTo("{\"one\":1}");
+
+    // assert empty fields don't show up on the struct
+    assertThrows(RuntimeException.class, () -> result.get("null"));
+    assertThrows(RuntimeException.class, () -> result.get("empty_obj"));
+    assertThrows(RuntimeException.class, () -> result.get("empty_arr"));
+    assertThrows(RuntimeException.class, () -> result.get("empty_arr_arr"));
+    assertThrows(RuntimeException.class, () -> result.get("array_empty_object"));
+  }
 }
-
-
-
-
-

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -99,7 +99,7 @@ class JsonToMapUtilsTest extends FileLoads {
   }
 
   @Test
-  @DisplayName("extractSimpleValue converts complex nodes to strings if schema is string")
+  @DisplayName("extractValue converts complex nodes to strings if schema is string")
   public void exactStringsFromComplexNodes() {
     JsonNode arrayObjects = objNode.get("array_objects");
     assertInstanceOf(ArrayNode.class, arrayObjects);

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -298,6 +298,7 @@ class JsonToMapUtilsTest extends FileLoads {
     assertThat(result.get("float_is_double")).isEqualTo(3.0);
     assertThat(result.get("double")).isEqualTo(0.3);
     // we don't actually convert to bytes when parsing the json
+    // so just check it is a string
     assertThat(result.get("bytes")).isEqualTo("SGVsbG8=");
     BigDecimal bigIntExpected = new BigDecimal(new BigInteger("354736184430273859332531123456"));
     assertThat(result.get("bigInt")).isEqualTo(bigIntExpected);

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Base64;
 import java.util.Map;
-
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.connect.data.Field;
@@ -177,12 +176,15 @@ class JsonToMapUtilsTest extends FileLoads {
     assertThat(JsonToMapUtils.schemaFromNode(intNode)).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
     assertThat(JsonToMapUtils.schemaFromNode(doubleNode)).isEqualTo(Schema.OPTIONAL_FLOAT64_SCHEMA);
   }
+
   @Test
   @DisplayName("schemaFromNode returns Map<String, String> for ObjectNodes")
   public void schmefromNodeObjectNodesAsMaps() {
     JsonNode node = objNode.get("nested_obj");
     assertInstanceOf(ObjectNode.class, node);
-    assertThat(JsonToMapUtils.schemaFromNode(node)).isEqualTo(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build());
+    assertThat(JsonToMapUtils.schemaFromNode(node))
+        .isEqualTo(
+            SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build());
   }
 
   @Test
@@ -315,7 +317,7 @@ class JsonToMapUtilsTest extends FileLoads {
         .isEqualTo(Lists.newArrayList(Lists.newArrayList("1"), Lists.newArrayList("2.0")));
     assertThat(result.get("array_different_types")).isEqualTo(Lists.newArrayList("one", "1"));
 
-    Map<String, String> expectedNestedObject  = Maps.newHashMap();
+    Map<String, String> expectedNestedObject = Maps.newHashMap();
     expectedNestedObject.put("key", "{\"nested_key\":1}");
     assertThat(result.get("nested_obj")).isEqualTo(expectedNestedObject);
 

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -32,8 +32,10 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.AbstractMap;
 import java.util.Base64;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -60,14 +62,18 @@ class JsonToMapUtilsTest extends FileLoads {
   }
 
   @Test
-  @DisplayName("addToSchema should add schemas to builder unless schema is null")
+  @DisplayName("addField should add schemas to builder unless schema is null")
   public void addToSchema() {
     SchemaBuilder builder = SchemaBuilder.struct();
-    JsonToMapUtils.addToSchema("good", Schema.STRING_SCHEMA, builder);
-    JsonToMapUtils.addToSchema("null", null, builder);
+    Map.Entry<String, JsonNode> good =
+        new AbstractMap.SimpleEntry<String, JsonNode>("good", TextNode.valueOf("text"));
+    Map.Entry<String, JsonNode> missing =
+        new AbstractMap.SimpleEntry<String, JsonNode>("missing", NullNode.getInstance());
+    JsonToMapUtils.addField(good, builder);
+    JsonToMapUtils.addField(missing, builder);
     Schema result = builder.build();
     assertThat(result.fields())
-        .isEqualTo(Lists.newArrayList(new Field("good", 0, Schema.STRING_SCHEMA)));
+        .isEqualTo(Lists.newArrayList(new Field("good", 0, Schema.OPTIONAL_STRING_SCHEMA)));
   }
 
   @Test

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -32,6 +32,8 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Base64;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -159,11 +161,12 @@ class JsonToMapUtilsTest extends FileLoads {
   }
 
   @Test
-  @DisplayName("schemaFromNode returns String schema for BigInteger nodes")
+  @DisplayName(
+      "schemaFromNode returns bytes with logical name decimal with scale 0 for BigInteger nodes")
   public void schemaFromNodeStringForBigInteger() {
     JsonNode node = objNode.get("bigInt");
     assertInstanceOf(BigIntegerNode.class, node);
-    assertThat(JsonToMapUtils.schemaFromNode(node)).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+    assertThat(JsonToMapUtils.schemaFromNode(node)).isEqualTo(JsonToMapUtils.decimalSchema(0));
   }
 
   @Test
@@ -301,8 +304,8 @@ class JsonToMapUtilsTest extends FileLoads {
     assertThat(result.get("double")).isEqualTo(0.3);
     // we don't actually convert to bytes when parsing the json
     assertThat(result.get("bytes")).isEqualTo("SGVsbG8=");
-    // no way to represent BigInteger in a SinkRecord w/o custom annotations
-    assertThat(result.get("bigInt")).isEqualTo("354736184430273859332531123456");
+    BigDecimal bigIntExpected = new BigDecimal(new BigInteger("354736184430273859332531123456"));
+    assertThat(result.get("bigInt")).isEqualTo(bigIntExpected);
     assertThat(result.get("nested_object_contains_empty"))
         .isEqualTo(Lists.newArrayList("{}", "{\"one\":1}"));
     assertThat(result.get("array_int")).isEqualTo(Lists.newArrayList(1, 1));

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -1,0 +1,267 @@
+package io.tabular.iceberg.connect.transforms;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.*;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonToMapUtilsTest extends FileLoads {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final ObjectNode objNode = loadJson(mapper);
+
+    private ObjectNode loadJson(ObjectMapper mapper) {
+        try {
+            return (ObjectNode) mapper.readTree(getFile("jsonmap.json"));
+        } catch (Exception e) {
+            throw new RuntimeException("failed to load jsonmap.json in test", e);
+        }
+    }
+
+    @Test
+    @DisplayName("addToSchema should add schemas to builder unless schema is null")
+    public void addToSchema() {
+        SchemaBuilder builder = SchemaBuilder.struct();
+        JsonToMapUtils.addToSchema("good", Schema.STRING_SCHEMA, builder);
+        JsonToMapUtils.addToSchema("null", null, builder);
+        Schema result = builder.build();
+        assertThat(result.fields()).isEqualTo(Lists.newArrayList(new Field("good", 0, Schema.STRING_SCHEMA)));
+    }
+
+    @Test
+    @DisplayName("extractSimpleValue extracts type from Node based on Schema")
+    public void primitiveBasedOnSchemaHappyPath() {
+        JsonNode stringNode = objNode.get("string");
+        JsonNode booleanNode = objNode.get("boolean");
+        JsonNode intNode = objNode.get("int");
+        JsonNode longNode = objNode.get("long");
+        JsonNode floatIsDoubleNode = objNode.get("float_is_double");
+        JsonNode doubleNode = objNode.get("double");
+        JsonNode bytesNode = objNode.get("bytes");
+
+        assertThat(JsonToMapUtils.extractSimpleValue(stringNode, Schema.Type.STRING, "")).isEqualTo("string");
+        assertThat(JsonToMapUtils.extractSimpleValue(booleanNode, Schema.Type.BOOLEAN, "")).isEqualTo(true);
+        assertThat(JsonToMapUtils.extractSimpleValue(intNode, Schema.Type.INT32, "")).isEqualTo(42);
+        assertThat(JsonToMapUtils.extractSimpleValue(longNode, Schema.Type.INT64,"")).isEqualTo(3147483647L);
+        assertThat(JsonToMapUtils.extractSimpleValue(floatIsDoubleNode, Schema.Type.FLOAT64, "")).isEqualTo(3.0);
+        assertThat(JsonToMapUtils.extractSimpleValue(doubleNode, Schema.Type.FLOAT64, "")).isEqualTo( 0.3);
+        byte[] byteResult = (byte[]) JsonToMapUtils.extractSimpleValue(bytesNode, Schema.Type.BYTES, "");
+        assertArrayEquals(byteResult, Base64.getDecoder().decode("SGVsbG8="));
+    }
+
+    @Test
+    @DisplayName("extractSimpleValue converts complex nodes to strings if schema is string")
+    public void exactStringsFromComplexNodes() {
+        JsonNode arrayObjects = objNode.get("array_objects");
+        assertInstanceOf(ArrayNode.class, arrayObjects);
+
+        JsonNode nestedObjNode = objNode.get("nested_obj");
+        assertInstanceOf(ObjectNode.class, nestedObjNode);
+
+        JsonNode arrayDifferentTypes = objNode.get("array_different_types");
+        assertInstanceOf(ArrayNode.class, arrayDifferentTypes);
+
+        JsonNode bigInt = objNode.get("bigInt");
+        assertInstanceOf(BigIntegerNode.class, bigInt);
+
+        assertThat(JsonToMapUtils.extractSimpleValue(arrayObjects, Schema.Type.STRING, "")).isEqualTo("[{\"key\":1}]");
+        assertThat(JsonToMapUtils.extractSimpleValue(nestedObjNode, Schema.Type.STRING, "")).isEqualTo("{\"one\":1}");
+        assertThat(JsonToMapUtils.extractSimpleValue(arrayDifferentTypes, Schema.Type.STRING, "")).isEqualTo("[\"one\",1]");
+        assertThat(JsonToMapUtils.extractSimpleValue(bigInt, Schema.Type.STRING, "")).isEqualTo("354736184430273859332531123456");
+    }
+
+    @Test
+    @DisplayName("extractSimpleValue throws for non-primitive schema types")
+    public void primitiveBasedOnSchemaThrows() {
+        assertThrows(RuntimeException.class, () -> JsonToMapUtils.extractSimpleValue(objNode.get("string"), Schema.Type.STRUCT, ""));
+    }
+
+    @Test
+    @DisplayName("arrayNodeType returns a type if all elements of the array are the same type")
+    public void determineArrayNodeType() {
+        ArrayNode arrayInt = (ArrayNode) objNode.get("array_int");
+        ArrayNode arrayArrayInt = (ArrayNode) objNode.get("array_array_int");
+        assertThat(IntNode.class).isEqualTo(JsonToMapUtils.arrayNodeType(arrayInt));
+        assertThat(ArrayNode.class).isEqualTo(JsonToMapUtils.arrayNodeType(arrayArrayInt));
+    }
+
+    @Test
+    @DisplayName("arrayNodeType returns null if elements of the array are different types")
+    public void determineArrayNodeTypeNotSameTypes() {
+        ArrayNode mixedArray = (ArrayNode) objNode.get("array_different_types");
+        assertThat(JsonToMapUtils.arrayNodeType(mixedArray)).isNull();
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns null for NullNode and MissingNode types")
+    public void schemaFromNodeNullOnNullNodes() {
+        JsonNode nullNode = NullNode.getInstance();
+        JsonNode missingNode = MissingNode.getInstance();
+        assertThat(JsonToMapUtils.schemaFromNode(nullNode)).isNull();
+        assertThat(JsonToMapUtils.schemaFromNode(missingNode)).isNull();
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns String schema for ObjectNodes")
+    public void schemaFromNodeStringsFromObjectNodes() {
+        assertThat(JsonToMapUtils.schemaFromNode(objNode)).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns null for empty ObjectNodes")
+    public void schemaFromNodeNullEmptyObjectNodes() {
+        JsonNode node = objNode.get("empty_obj");
+        assertInstanceOf(ObjectNode.class, node);
+        assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns String schema for BigInteger nodes")
+    public void schemaFromNodeStringForBigInteger() {
+        JsonNode node = objNode.get("bigInt");
+        assertInstanceOf(BigIntegerNode.class, node);
+        assertThat(JsonToMapUtils.schemaFromNode(node)).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns primitive Schemas for primitive nodes")
+    public void schemaFromNodePrimitiveSchemasFromPrimitiveNodes() {
+        JsonNode intNode = objNode.get("int");
+        JsonNode doubleNode = objNode.get("double");
+        assertInstanceOf(IntNode.class, intNode);
+        assertInstanceOf(DoubleNode.class, doubleNode);
+        assertThat(JsonToMapUtils.schemaFromNode(intNode)).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(JsonToMapUtils.schemaFromNode(doubleNode)).isEqualTo(Schema.OPTIONAL_FLOAT64_SCHEMA);
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns Array String schema for ArrayNodes with ObjectNode elements")
+    public void schemaFromNodeArrayStringFromArrayObjects() {
+        JsonNode arrayObjects = objNode.get("array_objects");
+        assertInstanceOf(ArrayNode.class, arrayObjects);
+        assertThat(JsonToMapUtils.schemaFromNode(arrayObjects)).isEqualTo(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns Array String schema for ArrayNodes with inconsistent types")
+    public void schemaFromNodeArrayStringFromInconsistentArrayNodes() {
+        JsonNode inconsistent = objNode.get("array_different_types");
+        assertInstanceOf(ArrayNode.class, inconsistent);
+        assertThat(JsonToMapUtils.schemaFromNode(inconsistent)).isEqualTo(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns Array[Array[String]] for ArrayNodes of ArrayNodes with inconsistent types")
+    public void schemaFromNodeArraysArrays() {
+        JsonNode node = objNode.get("array_array_inconsistent");
+        assertInstanceOf(ArrayNode.class, node);
+
+        Schema expected = SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build()).optional().build();
+        Schema result = JsonToMapUtils.schemaFromNode(node);
+        assertThat(result).isEqualTo(expected);
+    }
+    @Test
+    @DisplayName("schemaFromNode returns Array[Array[String]] for ArrayNodes of ArrayNodes of objects")
+    public void schemaFromNodeArrayArrayObjects() {
+        JsonNode node = objNode.get("array_array_objects");
+        assertInstanceOf(ArrayNode.class, node);
+        Schema expected = SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build()).optional().build();
+        Schema result = JsonToMapUtils.schemaFromNode(node);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns Array[Array[Int]] for ArrayNodes of ArrayNodes of IntNode")
+    public void schemaFromNodeArrayArrayOfArrayArrayInt() {
+        JsonNode node = objNode.get("array_array_int");
+        assertInstanceOf(ArrayNode.class, node);
+        Schema expected = SchemaBuilder.array(SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build()).optional().build();
+        Schema result = JsonToMapUtils.schemaFromNode(node);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns null for empty ArrayNodes")
+    public void schemaFromNodeNullFromEmptyArray() {
+        JsonNode node = objNode.get("empty_arr");
+        assertInstanceOf(ArrayNode.class, node);
+        assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
+    }
+    @Test
+    @DisplayName("schemaFromNode returns null for empty Array of Array nodes")
+    public void schemaFromNodeEmptyArrayOfEmptyArrays() {
+        JsonNode node = objNode.get("empty_arr_arr");
+        assertInstanceOf(ArrayNode.class, node);
+        assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
+    }
+
+    @Test
+    @DisplayName("schemaFromNode returns null for empty array of empty object")
+    public void schemaFromNodeNullArrayEmptyObject() {
+        JsonNode node = objNode.get("array_empty_object");
+        assertInstanceOf(ArrayNode.class, node);
+        assertThat(JsonToMapUtils.schemaFromNode(node)).isNull();
+    }
+    @Test
+    @DisplayName("schemaFromNode returns Array[String] for array of objects even if one object is empty")
+    public void schemaFromNodeMixedObjectsOneEmpty() {
+        JsonNode node = objNode.get("nested_object_contains_empty");
+        assertInstanceOf(ArrayNode.class, node);
+        Schema expected = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+        Schema result = JsonToMapUtils.schemaFromNode(node);
+        assertThat(result).isEqualTo(expected);
+    }
+
+   @Test
+   public void addToStruct() {
+       SchemaBuilder builder = SchemaBuilder.struct();
+       objNode.fields().forEachRemaining(entry -> JsonToMapUtils.addFieldSchemaBuilder(entry, builder));
+       Schema schema = builder.build();
+
+       Struct result = new Struct(schema);
+       JsonToMapUtils.addToStruct(objNode, schema, result);
+
+       assertThat(result.get("string")).isEqualTo("string");
+       assertThat(result.get("int")).isEqualTo(42);
+       assertThat(result.get("long")).isEqualTo(3147483647L);
+       assertThat(result.get("boolean")).isEqualTo(true);
+       assertThat(result.get("float_is_double")).isEqualTo(3.0);
+       assertThat(result.get("double")).isEqualTo(0.3);
+       // we don't actually convert to bytes when parsing the json
+       assertThat(result.get("bytes")).isEqualTo("SGVsbG8=");
+       // no way to represent BigInteger in a SinkRecord w/o custom annotations
+       assertThat(result.get("bigInt")).isEqualTo("354736184430273859332531123456");
+       assertThat(result.get("nested_object_contains_empty")).isEqualTo(Lists.newArrayList("{}", "{\"one\":1}"));
+       assertThat(result.get("array_int")).isEqualTo(Lists.newArrayList(1, 1));
+       assertThat(result.get("array_array_int")).isEqualTo(Lists.newArrayList(Lists.newArrayList(1,1), Lists.newArrayList(2,2)));
+       assertThat(result.get("array_objects")).isEqualTo(Lists.newArrayList("{\"key\":1}"));
+       assertThat(result.get("array_array_objects")).isEqualTo(Lists.newArrayList(Lists.newArrayList("{\"key\":1}"), Lists.newArrayList("{\"key\":2}")));
+       assertThat(result.get("array_array_inconsistent")).isEqualTo(Lists.newArrayList(Lists.newArrayList("1"), Lists.newArrayList("2.0")));
+       assertThat(result.get("array_different_types")).isEqualTo(Lists.newArrayList("one", "1"));
+       assertThat(result.get("nested_obj")).isEqualTo("{\"one\":1}");
+
+       // assert empty fields don't show up on the struct
+       assertThrows(RuntimeException.class, () -> result.get("null"));
+       assertThrows(RuntimeException.class, () -> result.get("empty_obj"));
+       assertThrows(RuntimeException.class, () -> result.get("empty_arr"));
+       assertThrows(RuntimeException.class, () -> result.get("empty_arr_arr"));
+       assertThrows(RuntimeException.class, () -> result.get("array_empty_object"));
+   }
+
+}
+
+
+
+
+

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -283,9 +283,7 @@ class JsonToMapUtilsTest extends FileLoads {
   @Test
   public void addToStruct() {
     SchemaBuilder builder = SchemaBuilder.struct();
-    objNode
-        .fields()
-        .forEachRemaining(entry -> JsonToMapUtils.addFieldSchemaBuilder(entry, builder));
+    objNode.fields().forEachRemaining(entry -> JsonToMapUtils.addField(entry, builder));
     Schema schema = builder.build();
 
     Struct result = new Struct(schema);

--- a/kafka-connect-transforms/src/test/resources/jsonmap.json
+++ b/kafka-connect-transforms/src/test/resources/jsonmap.json
@@ -9,6 +9,7 @@
   "empty_obj": {},
   "empty_arr": [],
   "empty_arr_arr": [[], []],
+  "empty_string": "",
   "array_empty_object": [{}, {}],
   "nested_object_contains_empty": [{}, {"one":  1}],
   "array_int": [1, 1],
@@ -21,5 +22,6 @@
     "key": {"nested_key": 1}
   },
   "bytes": "SGVsbG8=",
-  "bigInt": 354736184430273859332531123456
+  "bigInt": 354736184430273859332531123456,
+  "bigDecimal": 13.3333333333333333333333333344444444455555555
 }

--- a/kafka-connect-transforms/src/test/resources/jsonmap.json
+++ b/kafka-connect-transforms/src/test/resources/jsonmap.json
@@ -1,0 +1,25 @@
+{
+  "string": "string",
+  "int": 42,
+  "long": 3147483647,
+  "boolean": true,
+  "float_is_double": 3.0,
+  "double": 0.3,
+  "null": null,
+  "empty_obj": {},
+  "empty_arr": [],
+  "empty_arr_arr": [[], []],
+  "array_empty_object": [{}, {}],
+  "nested_object_contains_empty": [{}, {"one":  1}],
+  "array_int": [1, 1],
+  "array_array_int": [[1,1], [2,2]],
+  "array_objects": [{"key": 1}],
+  "array_array_objects":[[{"key":  1}], [{"key":  2}]],
+  "array_array_inconsistent": [[1], [2.0]],
+  "array_different_types": ["one", 1],
+  "nested_obj": {
+    "one": 1
+  },
+  "bytes": "SGVsbG8=",
+  "bigInt": 354736184430273859332531123456
+}

--- a/kafka-connect-transforms/src/test/resources/jsonmap.json
+++ b/kafka-connect-transforms/src/test/resources/jsonmap.json
@@ -15,7 +15,7 @@
   "array_int": [1, 1],
   "array_array_int": [[1,1], [2,2]],
   "array_objects": [{"key": 1}],
-  "array_array_objects":[[{"key":  1}], [{"key":  2}]],
+  "array_array_objects":[[{"key":  1}], [{"key":  2, "other": {"ugly": [1,2]}}]],
   "array_array_inconsistent": [[1], [2.0]],
   "array_different_types": ["one", 1],
   "nested_obj": {

--- a/kafka-connect-transforms/src/test/resources/jsonmap.json
+++ b/kafka-connect-transforms/src/test/resources/jsonmap.json
@@ -18,7 +18,7 @@
   "array_array_inconsistent": [[1], [2.0]],
   "array_different_types": ["one", 1],
   "nested_obj": {
-    "one": 1
+    "key": {"nested_key": 1}
   },
   "bytes": "SGVsbG8=",
   "bigInt": 354736184430273859332531123456


### PR DESCRIPTION
Best attempt at turning unstructured json into structs.

If the JSON is extremely inconsistent but you need to get it into Iceberg, configure this to be at `transfrom.json.root:true`.  This will create a single struct with a field named "payload" and a `Map<String, String>` for the value.

Default configuration (`transform.json.root:false`) will create a struct where all first-level primitives (int, long, string, etc.) become typed on the struct.  Nested objects become `Map<string, string>` fields to be parsed by the query engine.  Arrays of primitives get typed properly, including nested arrays of primitives.  Arrays of mixed types get converted to arrays of strings.

Empty nodes, empty arrays, empty objects are stripped from the struct/schema. 

Without this, the json schema inference in the connector will infer nested objects as Structs.  Inconsistent keys can lead to an explosion of schema evolutions and potentially hundreds to thousands of columns depending on the json.  This SMT can be used to avoid that by processing the json and defining a schema that has the nested objects as Maps. 