### PR TITLE
remove-configruations2-from-stripped-jar

### DIFF
--- a/kafka-connect-runtime/build.gradle
+++ b/kafka-connect-runtime/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     exclude group: "org.apache.zookeeper"
     exclude group: "org.apache.kerby"
     exclude group: "org.apache.hadoop", module: "hadoop-auth"
+    exclude group: "org.apache.commons", module: "commons-configuration2"
     exclude group: "org.apache.hadoop.thirdparty", module: "hadoop-shaded-protobuf_3_7"
     exclude group: "org.eclipse.jetty"
   }


### PR DESCRIPTION
Closes #225 

- hadoop-client brings in a version of commons-configuration w/ vulnerabilities
- we strip hadoop-client in the jar that goes to confluenthub
- add stripping commons-configuration2 as well so we can publish to confluent-hub