### PR TITLE
Dead letter table

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ http-client = { module =  "org.apache.httpcomponents.client5:httpclient5", versi
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-ver" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-ver" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-ver" }
+kafka-connect-runtime = {module = "org.apache.kafka:connect-runtime", version.ref = "kafka-ver"}
 mockito = "org.mockito:mockito-core:4.8.1"
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers-ver" }
 testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainers-ver" }

--- a/kafka-connect-deadletter/build.gradle
+++ b/kafka-connect-deadletter/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+  id "java-test-fixtures"
+}
+
+dependencies {
+  implementation libs.iceberg.core
+  implementation libs.iceberg.common
+  implementation libs.iceberg.guava
+  implementation libs.avro
+  compileOnly libs.bundles.kafka.connect
+
+
+  testImplementation libs.junit.api
+  testRuntimeOnly libs.junit.engine
+
+  testImplementation libs.mockito
+  testImplementation libs.assertj
+
+  testFixturesImplementation libs.iceberg.common
+  testFixturesImplementation libs.iceberg.core
+  testFixturesImplementation libs.avro
+}
+
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+      from components.java
+    }
+  }
+}

--- a/kafka-connect-deadletter/src/main/java/io/tabular/iceberg/connect/deadletter/DeadLetterUtils.java
+++ b/kafka-connect-deadletter/src/main/java/io/tabular/iceberg/connect/deadletter/DeadLetterUtils.java
@@ -31,6 +31,25 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 public class DeadLetterUtils {
 
+  public static class DeadLetterException extends RuntimeException {
+    private final String location;
+    private final Throwable error;
+
+    public DeadLetterException(String location, Throwable error) {
+      super(error);
+      this.location = location;
+      this.error = error;
+    }
+
+    public String getLocation() {
+      return location;
+    }
+
+    public Throwable getError() {
+      return error;
+    }
+  }
+
   private DeadLetterUtils() {
     throw new IllegalStateException("Should not be initialialized");
   }

--- a/kafka-connect-deadletter/src/main/java/io/tabular/iceberg/connect/deadletter/DeadLetterUtils.java
+++ b/kafka-connect-deadletter/src/main/java/io/tabular/iceberg/connect/deadletter/DeadLetterUtils.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.deadletter;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public class DeadLetterUtils {
+
+  private DeadLetterUtils() {
+    throw new IllegalStateException("Should not be initialialized");
+  }
+
+  public static final String KEY_BYTES = "key";
+  public static final String VALUE_BYTES = "value";
+  public static final String PAYLOAD_KEY = "transformed";
+  public static final String ORIGINAL_BYTES_KEY = "original";
+  private static final String HEADERS = "headers";
+  public static final Schema HEADER_ELEMENT_SCHEMA =
+      SchemaBuilder.struct()
+          .field("key", Schema.STRING_SCHEMA)
+          .field("value", Schema.OPTIONAL_BYTES_SCHEMA)
+          .optional()
+          .build();
+  public static final Schema HEADER_SCHEMA =
+      SchemaBuilder.array(HEADER_ELEMENT_SCHEMA).optional().build();
+  public static final Schema FAILED_SCHEMA =
+      SchemaBuilder.struct()
+          .name("failed_message")
+          .parameter("isFailed", "true")
+          .field("topic", Schema.STRING_SCHEMA)
+          .field("partition", Schema.INT32_SCHEMA)
+          .field("offset", Schema.INT64_SCHEMA)
+          .field("location", Schema.STRING_SCHEMA)
+          .field("timestamp", Schema.OPTIONAL_INT64_SCHEMA)
+          .field("exception", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("stack_trace", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("key_bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+          .field("value_bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+          .field(HEADERS, HEADER_SCHEMA)
+          .field("target_table", Schema.OPTIONAL_STRING_SCHEMA)
+          .schema();
+
+  public static String stackTrace(Throwable error) {
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    error.printStackTrace(pw);
+    return sw.toString();
+  }
+
+  public static class Values {
+    // expect byte[]
+    private final Object keyBytes;
+    // expect byte[]
+    private final Object valueBytes;
+    // expect List<Struct>
+    private final Object headers;
+
+    public Values(Object keyBytes, Object valueBytes, Object headers) {
+      this.keyBytes = keyBytes;
+      this.valueBytes = valueBytes;
+      this.headers = headers;
+    }
+
+    public Object getKeyBytes() {
+      return keyBytes;
+    }
+
+    public Object getValueBytes() {
+      return valueBytes;
+    }
+
+    public Object getHeaders() {
+      return headers;
+    }
+  }
+
+  public static SinkRecord failedRecord(SinkRecord original, Throwable error, String location) {
+    List<Struct> headers = null;
+    if (!original.headers().isEmpty()) {
+      headers = DeadLetterUtils.serializedHeaders(original);
+    }
+    Values values = new Values(original.key(), original.value(), headers);
+    return failedRecord(original, values, error, location, null);
+  }
+
+  private static SinkRecord failedRecord(
+      SinkRecord original, Values values, Throwable error, String location, String targetTable) {
+
+    Struct struct = new Struct(FAILED_SCHEMA);
+    struct.put("topic", original.topic());
+    struct.put("partition", original.kafkaPartition());
+    struct.put("offset", original.kafkaOffset());
+    struct.put("timestamp", original.timestamp());
+    struct.put("location", location);
+    struct.put("exception", error.toString());
+    String stack = stackTrace(error);
+    if (!stack.isEmpty()) {
+      struct.put("stack_trace", stackTrace(error));
+    }
+    if (values.getKeyBytes() != null) {
+      struct.put("key_bytes", values.getKeyBytes());
+    }
+    if (values.getValueBytes() != null) {
+      struct.put("value_bytes", values.getValueBytes());
+    }
+    if (values.getHeaders() != null) {
+      struct.put(HEADERS, values.getHeaders());
+    }
+    if (targetTable != null) {
+      struct.put("target_table", targetTable);
+    }
+
+    return original.newRecord(
+        original.topic(),
+        original.kafkaPartition(),
+        null,
+        null,
+        FAILED_SCHEMA,
+        struct,
+        original.timestamp());
+  }
+
+  /**
+   * No way to get back the original Kafka header bytes. We instead have an array with elements of
+   * {"key": String, "value": bytes} for each header. This can be converted back into a Kafka
+   * Connect header by the user later, and further converted into Kafka RecordHeaders to be put back
+   * into a ProducerRecord to create the original headers on the Kafka record.
+   *
+   * @param original record where headers are still byte array values
+   * @return Struct for an Array that can be put into Iceberg
+   */
+  public static List<Struct> serializedHeaders(SinkRecord original) {
+    List<Struct> headers = Lists.newArrayList();
+    for (Header header : original.headers()) {
+      Struct headerStruct = new Struct(HEADER_ELEMENT_SCHEMA);
+      headerStruct.put("key", header.key());
+      headerStruct.put("value", header.value());
+      headers.add(headerStruct);
+    }
+    return headers;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static SinkRecord mapToFailedRecord(
+      String targetTable, SinkRecord record, String location, Throwable error) {
+    Map<String, Object> payload = (Map<String, Object>) record.value();
+    Map<String, Object> bytes = (Map<String, Object>) payload.get(ORIGINAL_BYTES_KEY);
+    Object keyBytes = bytes.get(KEY_BYTES);
+    Object valueBytes = bytes.get(VALUE_BYTES);
+    Object headers = bytes.get(HEADERS);
+    Values values = new Values(keyBytes, valueBytes, headers);
+    return failedRecord(record, values, error, location, targetTable);
+  }
+}

--- a/kafka-connect-transforms/build.gradle
+++ b/kafka-connect-transforms/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
   testImplementation libs.mockito
   testImplementation libs.assertj
+  testRuntimeOnly libs.kafka.connect.runtime
 }
 
 configurations {

--- a/kafka-connect-transforms/build.gradle
+++ b/kafka-connect-transforms/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+  implementation project(":iceberg-kafka-connect-deadletter")
   implementation libs.iceberg.guava
   implementation libs.slf4j
   compileOnly libs.bundles.kafka.connect

--- a/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/ErrorTransform.java
+++ b/kafka-connect-transforms/src/main/java/io/tabular/iceberg/connect/transforms/ErrorTransform.java
@@ -1,0 +1,462 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transforms;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+/**
+ * Wraps key, value, header converters and SMTs in order to catch exceptions. Failed records are
+ * converted into a standard struct and sent to the connector to be put into Iceberg
+ *
+ * <p>MUST ONLY BE USED with `value.converter`, `key.converter`, and `header.converter` set to
+ * "org.apache.kafka.connect.converters.ByteArrayConverter" which can not be validated from within
+ * this SMT
+ *
+ * <p>Actual value converter, key converter, and header converter are configured on the
+ * `transforms.xxx` key where xxx is the name of this transform. See example for how properties are
+ * passed and namespaced
+ *
+ * <p>"transforms": "tab", "transforms.tab.type":
+ * "io.tabular.iceberg.connect.transform.managed.ManagedTransform",
+ * "transforms.tab.value.converter": "org.apache.kafka.connect.storage.StringConverter",
+ * "transforms.tab.value.converter.some_property: "...", "transforms.tab.key.converter":
+ * "org.apache.kafka.connect.storage.StringConverter", "transforms.tab.key.converter.some_property":
+ * "...", "transforms.tab.smts" : "some.java.class,some.other.java.class",
+ * "transforms.tab.smts.prop1" : "some_property_for_the_smts"
+ *
+ * <p>This should not be used with any other SMT. All SMTs should be added to "transforms.tab.smts".
+ *
+ * <p>It returns a special Map of String -> Object "original" : Map of String -> Object containing
+ * the key,value, and header bytes of the original message "transformed" : [null, Struct, Map, etc.]
+ * of whatever the deserialized record is (after transformation if SMTs are configured)
+ *
+ * <p>The original payload can be used in the Iceberg Connector if the record cannot be transformed
+ * to an Iceberg record so that the original kafka message can be stored in Iceberg at that point.
+ *
+ * <p>If any of the key, value, header deserializers or SMTs throw an exception a failed record is
+ * constructed that contains kafka metadata, exception/location information, and the original
+ * key/value/header bytes.
+ */
+public class ErrorTransform implements Transformation<SinkRecord> {
+
+  public static class TransformInitializationException extends RuntimeException {
+    TransformInitializationException(String errorMessage) {
+      super(errorMessage);
+    }
+
+    TransformInitializationException(String errorMessage, Throwable err) {
+      super(errorMessage, err);
+    }
+  }
+
+  public static class PropsParser {
+    static Map<String, ?> apply(Map<String, ?> props, String target) {
+      return props.entrySet().stream()
+          .filter(
+              entry ->
+                  (!Objects.equals(entry.getKey(), target)) && (entry.getKey().startsWith(target)))
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().replaceFirst("^" + target + ".", ""),
+                  Map.Entry::getValue));
+    }
+  }
+
+  private static class DeserializedRecord {
+    private final SinkRecord record;
+    private final boolean failed;
+
+    DeserializedRecord(SinkRecord record, boolean failed) {
+      this.record = record;
+      this.failed = failed;
+    }
+
+    public SinkRecord getRecord() {
+      return record;
+    }
+
+    public boolean isFailed() {
+      return failed;
+    }
+  }
+
+  private abstract static class ExceptionHandler {
+    SinkRecord handle(SinkRecord original, Throwable error, String location) {
+      throw new java.lang.IllegalStateException("handle not implemented");
+    }
+
+    protected final SinkRecord failedRecord(SinkRecord original, Throwable error, String location) {
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      error.printStackTrace(pw);
+      String stackTrace = sw.toString();
+      Struct struct = new Struct(FAILED_SCHEMA);
+      struct.put("topic", original.topic());
+      struct.put("partition", original.kafkaPartition());
+      struct.put("offset", original.kafkaOffset());
+      struct.put("timestamp", original.timestamp());
+      struct.put("location", location);
+      struct.put("exception", error.toString());
+      struct.put("stack_trace", stackTrace);
+      struct.put("key_bytes", original.key());
+      struct.put("value_bytes", original.value());
+
+      if (!original.headers().isEmpty()) {
+        List<Struct> headers = serializedHeaders(original);
+        struct.put(HEADERS, headers);
+      }
+
+      return original.newRecord(
+          original.topic(),
+          original.kafkaPartition(),
+          null,
+          null,
+          FAILED_SCHEMA,
+          struct,
+          original.timestamp());
+    }
+  }
+
+  private static class AllExceptions extends ExceptionHandler {
+    @Override
+    SinkRecord handle(SinkRecord original, Throwable error, String location) {
+      return failedRecord(original, error, location);
+    }
+  }
+
+  private static final String PAYLOAD_KEY = "transformed";
+  private static final String ORIGINAL_BYTES_KEY = "original";
+  private static final String KEY_BYTES = "key";
+  private static final String VALUE_BYTES = "value";
+  private static final String HEADERS = "headers";
+  private static final String KEY_CONVERTER = "key.converter";
+  private static final String VALUE_CONVERTER = "value.converter";
+  private static final String HEADER_CONVERTER = "header.converter";
+  private static final String TRANSFORMATIONS = "smts";
+  private static final String KEY_FAILURE = "KEY_CONVERTER";
+  private static final String VALUE_FAILURE = "VALUE_CONVERTER";
+  private static final String HEADER_FAILURE = "HEADER_CONVERTER";
+  private static final String SMT_FAILURE = "SMT_FAILURE";
+  static final Schema HEADER_ELEMENT_SCHEMA =
+      SchemaBuilder.struct()
+          .field("key", Schema.STRING_SCHEMA)
+          .field("value", Schema.OPTIONAL_BYTES_SCHEMA)
+          .optional()
+          .build();
+  static final Schema HEADER_SCHEMA = SchemaBuilder.array(HEADER_ELEMENT_SCHEMA).optional().build();
+  static final Schema FAILED_SCHEMA =
+      SchemaBuilder.struct()
+          .name("failed_message")
+          .parameter("isFailed", "true")
+          .field("topic", Schema.STRING_SCHEMA)
+          .field("partition", Schema.INT32_SCHEMA)
+          .field("offset", Schema.INT64_SCHEMA)
+          .field("location", Schema.STRING_SCHEMA)
+          .field("timestamp", Schema.OPTIONAL_INT64_SCHEMA)
+          .field("exception", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("stack_trace", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("key_bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+          .field("value_bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+          .field(HEADERS, HEADER_SCHEMA)
+          .field("target_table", Schema.OPTIONAL_STRING_SCHEMA)
+          .schema();
+
+  private ExceptionHandler errorHandler;
+  private List<Transformation<SinkRecord>> smts;
+  private Function<SinkRecord, SchemaAndValue> keyConverter;
+  private Function<SinkRecord, SchemaAndValue> valueConverter;
+  private Function<SinkRecord, Headers> headerConverterFn;
+
+  public static final ConfigDef CONFIG_DEF =
+      new ConfigDef()
+          .define(
+              KEY_CONVERTER,
+              ConfigDef.Type.STRING,
+              "org.apache.kafka.connect.converters.ByteArrayConverter",
+              ConfigDef.Importance.MEDIUM,
+              "key.converter")
+          .define(
+              VALUE_CONVERTER,
+              ConfigDef.Type.STRING,
+              null,
+              ConfigDef.Importance.MEDIUM,
+              "value.converter")
+          .define(
+              HEADER_CONVERTER,
+              ConfigDef.Type.STRING,
+              "org.apache.kafka.connect.converters.ByteArrayConverter",
+              ConfigDef.Importance.MEDIUM,
+              "header.converter")
+          .define(
+              TRANSFORMATIONS, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM, "smts");
+
+  @Override
+  public SinkRecord apply(SinkRecord record) {
+    // tombstones returned as-is
+    if (record == null || record.value() == null) {
+      return record;
+    }
+
+    DeserializedRecord deserialized = deserialize(record);
+    if (deserialized.isFailed()) {
+      return deserialized.getRecord();
+    }
+
+    SinkRecord transformedRecord = deserialized.getRecord();
+
+    for (Transformation<SinkRecord> smt : smts) {
+      try {
+        transformedRecord = smt.apply(transformedRecord);
+        if (transformedRecord == null) {
+          break;
+        }
+      } catch (Exception e) {
+        return errorHandler.handle(record, e, SMT_FAILURE);
+      }
+    }
+    // SMT could filter out messages
+    if (transformedRecord == null) {
+      return null;
+    }
+
+    return newRecord(record, transformedRecord);
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  @Override
+  public void close() {}
+
+  /*
+  Kafka Connect filters the properties it passes to the SMT to
+  only the keys under the `transform.xxx` name.
+  */
+  @SuppressWarnings("unchecked")
+  @Override
+  public void configure(Map<String, ?> props) {
+    SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+    ClassLoader loader = this.getClass().getClassLoader();
+
+    if (Objects.equals(
+        config.getString(KEY_CONVERTER),
+        "org.apache.kafka.connect.converters.ByteArrayConverter")) {
+      keyConverter = record -> new SchemaAndValue(record.keySchema(), record.value());
+    } else {
+      Converter converter = (Converter) loadClass(config.getString(KEY_CONVERTER), loader);
+      converter.configure(PropsParser.apply(props, KEY_CONVERTER), true);
+      keyConverter = record -> converter.toConnectData(record.topic(), (byte[]) record.key());
+    }
+
+    if (config.getString(VALUE_CONVERTER) == null) {
+      throw new TransformInitializationException(
+          "ManagedTransformWrapper cannot be used without a defined value converter");
+    } else {
+      Converter converter = (Converter) loadClass(config.getString(VALUE_CONVERTER), loader);
+      converter.configure(PropsParser.apply(props, VALUE_CONVERTER), false);
+      valueConverter = record -> converter.toConnectData(record.topic(), (byte[]) record.value());
+    }
+
+    HeaderConverter headerConverter;
+
+    if (Objects.equals(
+        config.getString(HEADER_CONVERTER),
+        "org.apache.kafka.connect.converters.ByteArrayConverter")) {
+      try (HeaderConverter converter =
+          (HeaderConverter)
+              loadClass("org.apache.kafka.connect.converters.ByteArrayConverter", loader)) {
+        converter.configure(PropsParser.apply(props, HEADER_CONVERTER));
+        headerConverter = converter;
+      } catch (Exception e) {
+        throw new TransformInitializationException(
+            String.format(
+                "Error loading header converter class %s", config.getString(HEADER_CONVERTER)),
+            e);
+      }
+      headerConverterFn = ConnectRecord::headers;
+    } else {
+      try (HeaderConverter converter =
+          (HeaderConverter) loadClass(config.getString(HEADER_CONVERTER), loader)) {
+        converter.configure(PropsParser.apply(props, HEADER_CONVERTER));
+        headerConverter = converter;
+      } catch (Exception e) {
+        throw new TransformInitializationException(
+            String.format(
+                "Error loading header converter class %s", config.getString(HEADER_CONVERTER)),
+            e);
+      }
+
+      headerConverterFn =
+          record -> {
+            Headers newHeaders = new ConnectHeaders();
+            Headers recordHeaders = record.headers();
+            if (recordHeaders != null) {
+              String topic = record.topic();
+              for (Header recordHeader : recordHeaders) {
+                SchemaAndValue schemaAndValue =
+                    headerConverter.toConnectHeader(
+                        topic, recordHeader.key(), (byte[]) recordHeader.value());
+                newHeaders.add(recordHeader.key(), schemaAndValue);
+              }
+            }
+            return newHeaders;
+          };
+    }
+
+    if (config.getString(TRANSFORMATIONS) == null) {
+      smts = Lists.newArrayList();
+    } else {
+
+      smts =
+          Arrays.stream(config.getString(TRANSFORMATIONS).split(","))
+              .map(className -> loadClass(className, loader))
+              .map(obj -> (Transformation<SinkRecord>) obj)
+              .peek(smt -> smt.configure(PropsParser.apply(props, TRANSFORMATIONS)))
+              .collect(Collectors.toList());
+    }
+
+    errorHandler = new AllExceptions();
+  }
+
+  private Object loadClass(String name, ClassLoader loader) {
+    if (name == null || name.isEmpty()) {
+      throw new TransformInitializationException("cannot initialize empty class");
+    }
+    Object obj;
+    try {
+      Class<?> clazz = Class.forName(name, true, loader);
+      obj = clazz.getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      throw new TransformInitializationException(
+          String.format("could not initialize class %s", name), e);
+    }
+    return obj;
+  }
+
+  private DeserializedRecord deserialize(SinkRecord record) {
+    SchemaAndValue keyData;
+    SchemaAndValue valueData;
+    Headers newHeaders;
+
+    try {
+      keyData = keyConverter.apply(record);
+    } catch (Exception e) {
+      return new DeserializedRecord(errorHandler.handle(record, e, KEY_FAILURE), true);
+    }
+
+    try {
+      valueData = valueConverter.apply(record);
+    } catch (Exception e) {
+      return new DeserializedRecord(errorHandler.handle(record, e, VALUE_FAILURE), true);
+    }
+    try {
+      newHeaders = headerConverterFn.apply(record);
+    } catch (Exception e) {
+      return new DeserializedRecord(errorHandler.handle(record, e, HEADER_FAILURE), true);
+    }
+
+    return new DeserializedRecord(
+        record.newRecord(
+            record.topic(),
+            record.kafkaPartition(),
+            keyData.schema(),
+            keyData.value(),
+            valueData.schema(),
+            valueData.value(),
+            record.timestamp(),
+            newHeaders),
+        false);
+  }
+
+  private SinkRecord newRecord(SinkRecord original, SinkRecord transformed) {
+    Map<String, Object> bytes = Maps.newHashMap();
+
+    if (original.key() != null) {
+      bytes.put(KEY_BYTES, original.key());
+    }
+    if (original.value() == null) {
+      throw new IllegalStateException("newRecord called with null value for record.value");
+    }
+
+    if (!original.headers().isEmpty()) {
+      bytes.put(HEADERS, serializedHeaders(original));
+    }
+
+    bytes.put(VALUE_BYTES, original.value());
+
+    Map<String, Object> result = Maps.newHashMap();
+    result.put(PAYLOAD_KEY, transformed);
+    result.put(ORIGINAL_BYTES_KEY, bytes);
+
+    return transformed.newRecord(
+        transformed.topic(),
+        transformed.kafkaPartition(),
+        null,
+        null,
+        null,
+        result,
+        transformed.timestamp(),
+        transformed.headers());
+  }
+
+  /**
+   * No way to get back the original Kafka header bytes. We instead have an array with elements of
+   * {"key": String, "value": bytes} for each header. This can be converted back into a Kafka
+   * Connect header by the user later, and further converted into Kafka RecordHeaders to be put back
+   * into a ProducerRecord to create the original headers on the Kafka record.
+   *
+   * @param original record where headers are still byte array values
+   * @return Struct for an Array that can be put into Iceberg
+   */
+  private static List<Struct> serializedHeaders(SinkRecord original) {
+    List<Struct> headers = Lists.newArrayList();
+    for (Header header : original.headers()) {
+      Struct headerStruct = new Struct(HEADER_ELEMENT_SCHEMA);
+      headerStruct.put("key", header.key());
+      headerStruct.put("value", header.value());
+      headers.add(headerStruct);
+    }
+    return headers;
+  }
+}

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/ErrorTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/ErrorTransformTest.java
@@ -21,6 +21,7 @@ package io.tabular.iceberg.connect.transforms;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.tabular.iceberg.connect.deadletter.DeadLetterUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -237,7 +238,7 @@ public class ErrorTransformTest {
       SinkRecord result =
           smt.apply(createRecord(malformedKey, VALUE_STRING, stringAsByteHeaders()));
       assertThat(result.keySchema()).isNull();
-      assertThat(result.valueSchema()).isEqualTo(ErrorTransform.FAILED_SCHEMA);
+      assertThat(result.valueSchema()).isEqualTo(DeadLetterUtils.FAILED_SCHEMA);
       assertThat(result.valueSchema().name()).isEqualTo("failed_message");
       assertThat(result.value()).isInstanceOf(Struct.class);
       Struct value = (Struct) result.value();
@@ -281,7 +282,7 @@ public class ErrorTransformTest {
       SinkRecord result =
           smt.apply(createRecord(KEY_STRING, malformedValue, stringAsByteHeaders()));
       assertThat(result.keySchema()).isNull();
-      assertThat(result.valueSchema()).isEqualTo(ErrorTransform.FAILED_SCHEMA);
+      assertThat(result.valueSchema()).isEqualTo(DeadLetterUtils.FAILED_SCHEMA);
       assertThat(result.valueSchema().name()).isEqualTo("failed_message");
       assertThat(result.value()).isInstanceOf(Struct.class);
       Struct value = (Struct) result.value();
@@ -332,7 +333,7 @@ public class ErrorTransformTest {
       SinkRecord record = createRecord(KEY_STRING, VALUE_STRING, headers);
       SinkRecord result = smt.apply(record);
       assertThat(result.keySchema()).isNull();
-      assertThat(result.valueSchema()).isEqualTo(ErrorTransform.FAILED_SCHEMA);
+      assertThat(result.valueSchema()).isEqualTo(DeadLetterUtils.FAILED_SCHEMA);
       assertThat(result.valueSchema().name()).isEqualTo("failed_message");
       assertThat(result.value()).isInstanceOf(Struct.class);
       Struct value = (Struct) result.value();
@@ -379,7 +380,7 @@ public class ErrorTransformTest {
       SinkRecord record = createRecord(KEY_STRING, VALUE_STRING, stringAsByteHeaders());
       SinkRecord result = smt.apply(record);
       assertThat(result.keySchema()).isNull();
-      assertThat(result.valueSchema()).isEqualTo(ErrorTransform.FAILED_SCHEMA);
+      assertThat(result.valueSchema()).isEqualTo(DeadLetterUtils.FAILED_SCHEMA);
       assertThat(result.valueSchema().name()).isEqualTo("failed_message");
       assertThat(result.value()).isInstanceOf(Struct.class);
       Struct value = (Struct) result.value();

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/ErrorTransformTest.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/ErrorTransformTest.java
@@ -1,0 +1,493 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ErrorTransformTest {
+
+  private static final String TOPIC = "some-topic";
+  private static final int PARTITION = 3;
+  private static final long OFFSET = 100;
+  private static final long TIMESTAMP = 1000;
+  private static final String KEY_STRING = "key";
+  private static final String VALUE_STRING = "value";
+  private static final String KEY_JSON = "{\"key\": \"blah\"}";
+  private static final String VALUE_JSON = "{\"a\": 1, \"b\": \"b\"}";
+  private static final String BYTE_ARRAY_CONVERTER =
+      "org.apache.kafka.connect.converters.ByteArrayConverter";
+  private static final String JSON_CONVERTER = "org.apache.kafka.connect.json.JsonConverter";
+  private static final String STRING_CONVERTER = "org.apache.kafka.connect.storage.StringConverter";
+
+  private Headers stringAsByteHeaders() {
+    Headers headers = new ConnectHeaders();
+    headers.add(
+        "h1", new SchemaAndValue(Schema.BYTES_SCHEMA, "h1".getBytes(StandardCharsets.UTF_8)));
+    return headers;
+  }
+
+  private SinkRecord createRecord(String key, String value, Headers headers) {
+    byte[] valueBytes = (value == null) ? null : value.getBytes(StandardCharsets.UTF_8);
+    byte[] keyBytes = (key == null) ? null : key.getBytes(StandardCharsets.UTF_8);
+
+    return new SinkRecord(
+        TOPIC,
+        PARTITION,
+        null,
+        keyBytes,
+        null,
+        valueBytes,
+        OFFSET,
+        TIMESTAMP,
+        TimestampType.CREATE_TIME,
+        headers);
+  }
+
+  @Test
+  @DisplayName(
+      "It should deserialize using the supplied converters into the custom SinkRecord shape with original/transformed result")
+  public void deserialize() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+      smt.configure(
+          ImmutableMap.of(
+              "value.converter",
+              STRING_CONVERTER,
+              "key.converter",
+              STRING_CONVERTER,
+              "header.converter",
+              STRING_CONVERTER,
+              "header.converter.converter.type",
+              "header"));
+      SinkRecord result = smt.apply(createRecord(KEY_STRING, VALUE_STRING, stringAsByteHeaders()));
+
+      assertThat(result.keySchema()).isNull();
+      assertThat(result.value()).isInstanceOf(Map.class);
+      Map<?, ?> value = (Map<?, ?>) result.value();
+
+      // can't assert on map due to byte array equality
+      Map<?, ?> original = (Map<?, ?>) value.get("original");
+      byte[] valueBytes = (byte[]) original.get("value");
+      byte[] keyBytes = (byte[]) original.get("key");
+      assertThat(valueBytes).isEqualTo(VALUE_STRING.getBytes(StandardCharsets.UTF_8));
+      assertThat(keyBytes).isEqualTo(KEY_STRING.getBytes(StandardCharsets.UTF_8));
+
+      assertThat(original.get("headers")).isInstanceOf(ArrayList.class);
+      List<?> resultHeaders = (List<?>) (original.get("headers"));
+      assertThat(resultHeaders).isNotEmpty();
+
+      Struct headerElement = (Struct) resultHeaders.get(0);
+      assertThat(headerElement.get("key")).isEqualTo("h1");
+      assertThat((byte[]) headerElement.get("value"))
+          .isEqualTo("h1".getBytes(StandardCharsets.UTF_8));
+
+      assertThat(value.get("transformed")).isInstanceOf(SinkRecord.class);
+      SinkRecord transformed = (SinkRecord) value.get("transformed");
+      assertThat(transformed.value()).isEqualTo(VALUE_STRING);
+      assertThat(transformed.valueSchema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+      assertThat(transformed.key()).isEqualTo(KEY_STRING);
+      assertThat(transformed.keySchema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+      assertThat(transformed.topic()).isEqualTo(TOPIC);
+      assertThat(transformed.kafkaPartition()).isEqualTo(PARTITION);
+      assertThat(transformed.kafkaOffset()).isEqualTo(OFFSET);
+
+      ConnectHeaders expectedHeaders = new ConnectHeaders();
+      expectedHeaders.add("h1", new SchemaAndValue(Schema.OPTIONAL_STRING_SCHEMA, "h1"));
+      assertThat(transformed.headers()).isEqualTo(expectedHeaders);
+    }
+  }
+
+  @Test
+  @DisplayName("It should not have a key entry for original bytes if the key was null")
+  public void nullKey() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+      smt.configure(
+          ImmutableMap.of("value.converter", STRING_CONVERTER, "key.converter", STRING_CONVERTER));
+      SinkRecord result = smt.apply(createRecord(null, VALUE_STRING, null));
+
+      assertThat(result.keySchema()).isNull();
+      assertThat(result.value()).isInstanceOf(Map.class);
+      Map<?, ?> value = (Map<?, ?>) result.value();
+      Map<?, ?> original = (Map<?, ?>) value.get("original");
+
+      assertThat(original.containsKey("value")).isTrue();
+      assertThat(original.containsKey("key")).isFalse();
+    }
+  }
+
+  @Test
+  @DisplayName("It should apply the configured nested SMT transforms")
+  public void smt() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+
+      String transformString = "_transformed";
+
+      smt.configure(
+          ImmutableMap.of(
+              "value.converter",
+              STRING_CONVERTER,
+              "key.converter",
+              STRING_CONVERTER,
+              "smts",
+              "io.tabular.iceberg.connect.transforms.TestStringTransform,io.tabular.iceberg.connect.transforms.TestStringTransform",
+              "smts.transform_text",
+              transformString));
+      SinkRecord result = smt.apply(createRecord(KEY_STRING, VALUE_STRING, null));
+
+      assertThat(result.value()).isInstanceOf(Map.class);
+      Map<?, ?> value = (Map<?, ?>) result.value();
+
+      assertThat(value.get("transformed")).isInstanceOf(SinkRecord.class);
+      SinkRecord transformed = (SinkRecord) value.get("transformed");
+      // each transformer appends _transformed to the original value
+      // we are configured with two transform appenders
+      assertThat(transformed.value()).isEqualTo(VALUE_STRING + "_transformed_transformed");
+      assertThat(transformed.key()).isEqualTo(KEY_STRING);
+      assertThat(transformed.keySchema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+      assertThat(transformed.topic()).isEqualTo(TOPIC);
+      assertThat(transformed.kafkaPartition()).isEqualTo(PARTITION);
+      assertThat(transformed.kafkaOffset()).isEqualTo(OFFSET);
+      assertThat(transformed.headers()).isEqualTo(new ConnectHeaders());
+    }
+  }
+
+  @Test
+  @DisplayName("Tombstone records should be returned as-is")
+  public void tombstone() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+      smt.configure(
+          ImmutableMap.of("value.converter", STRING_CONVERTER, "key.converter", STRING_CONVERTER));
+      SinkRecord record = createRecord(null, null, null);
+      assertThat(smt.apply(record)).isSameAs(record);
+    }
+  }
+
+  @Test
+  @DisplayName("Should return null if SMT filters out message")
+  public void nullFilteredBySMT() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+
+      String transformString = "_transformed";
+
+      smt.configure(
+          ImmutableMap.of(
+              "value.converter",
+              STRING_CONVERTER,
+              "key.converter",
+              STRING_CONVERTER,
+              "smts",
+              "io.tabular.iceberg.connect.transforms.TestStringTransform,io.tabular.iceberg.connect.transforms.TestStringTransform",
+              "smts.transform_text",
+              transformString,
+              "smts.null",
+              "true"));
+      SinkRecord result = smt.apply(createRecord(KEY_STRING, VALUE_STRING, null));
+
+      assertThat(result).isNull();
+    }
+  }
+
+  @Test
+  @DisplayName("Should return failed SinkRecord if key deserializer fails")
+  public void keyFailed() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+      smt.configure(
+          ImmutableMap.of(
+              "value.converter",
+              STRING_CONVERTER,
+              "key.converter",
+              JSON_CONVERTER,
+              "header.converter",
+              STRING_CONVERTER,
+              "header.converter.converter.type",
+              "header"));
+
+      String malformedKey = "{\"malformed_json\"\"\"{}{}{}{}**";
+      SinkRecord result =
+          smt.apply(createRecord(malformedKey, VALUE_STRING, stringAsByteHeaders()));
+      assertThat(result.keySchema()).isNull();
+      assertThat(result.valueSchema()).isEqualTo(ErrorTransform.FAILED_SCHEMA);
+      assertThat(result.valueSchema().name()).isEqualTo("failed_message");
+      assertThat(result.value()).isInstanceOf(Struct.class);
+      Struct value = (Struct) result.value();
+      assertThat(value.get("topic")).isEqualTo(TOPIC);
+      assertThat(value.get("partition")).isEqualTo(PARTITION);
+      assertThat(value.get("offset")).isEqualTo(OFFSET);
+      assertThat(value.get("location")).isEqualTo("KEY_CONVERTER");
+      assertThat(((String) value.get("stack_trace")).contains("JsonConverter")).isTrue();
+      assertThat(((String) value.get("exception")).contains("DataException")).isTrue();
+      assertThat((byte[]) value.get("key_bytes"))
+          .isEqualTo(malformedKey.getBytes(StandardCharsets.UTF_8));
+      assertThat((byte[]) value.get("value_bytes"))
+          .isEqualTo(VALUE_STRING.getBytes(StandardCharsets.UTF_8));
+
+      assertThat(value.get("headers")).isInstanceOf(List.class);
+      List<?> resultHeaders = (List<?>) (value.get("headers"));
+      assertThat(resultHeaders).isNotEmpty();
+      Struct headerElement = (Struct) resultHeaders.get(0);
+      assertThat(headerElement.get("key")).isEqualTo("h1");
+      assertThat((byte[]) headerElement.get("value"))
+          .isEqualTo("h1".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  @DisplayName("Should return failed SinkRecord if value deserializer fails")
+  public void valueFailed() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+      smt.configure(
+          ImmutableMap.of(
+              "value.converter",
+              JSON_CONVERTER,
+              "key.converter",
+              STRING_CONVERTER,
+              "header.converter",
+              STRING_CONVERTER,
+              "header.converter.converter.type",
+              "header"));
+
+      String malformedValue = "{\"malformed_json\"\"\"{}{}{}{}**";
+      SinkRecord result =
+          smt.apply(createRecord(KEY_STRING, malformedValue, stringAsByteHeaders()));
+      assertThat(result.keySchema()).isNull();
+      assertThat(result.valueSchema()).isEqualTo(ErrorTransform.FAILED_SCHEMA);
+      assertThat(result.valueSchema().name()).isEqualTo("failed_message");
+      assertThat(result.value()).isInstanceOf(Struct.class);
+      Struct value = (Struct) result.value();
+      assertThat(value.get("topic")).isEqualTo(TOPIC);
+      assertThat(value.get("partition")).isEqualTo(PARTITION);
+      assertThat(value.get("offset")).isEqualTo(OFFSET);
+      assertThat(value.get("location")).isEqualTo("VALUE_CONVERTER");
+      assertThat(((String) value.get("stack_trace")).contains("JsonConverter")).isTrue();
+      assertThat(((String) value.get("exception")).contains("DataException")).isTrue();
+      assertThat((byte[]) value.get("key_bytes"))
+          .isEqualTo(KEY_STRING.getBytes(StandardCharsets.UTF_8));
+      assertThat((byte[]) value.get("value_bytes"))
+          .isEqualTo(malformedValue.getBytes(StandardCharsets.UTF_8));
+
+      assertThat(value.get("headers")).isInstanceOf(List.class);
+      List<?> resultHeaders = (ArrayList<?>) (value.get("headers"));
+      assertThat(resultHeaders).isNotEmpty();
+      Struct headerElement = (Struct) resultHeaders.get(0);
+      assertThat(headerElement.get("key")).isEqualTo("h1");
+      assertThat((byte[]) headerElement.get("value"))
+          .isEqualTo("h1".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  @DisplayName("Should return failed SinkRecord if header deserializer fails")
+  public void headerFailed() {
+    String malformedValue = "{\"malformed_json\"\"\"{}{}{}{}**";
+    Headers headers = new ConnectHeaders();
+    headers.add(
+        "h1",
+        new SchemaAndValue(Schema.BYTES_SCHEMA, malformedValue.getBytes(StandardCharsets.UTF_8)));
+
+    try (ErrorTransform smt = new ErrorTransform()) {
+      smt.configure(
+          ImmutableMap.of(
+              "value.converter",
+              STRING_CONVERTER,
+              "key.converter",
+              STRING_CONVERTER,
+              "header.converter",
+              JSON_CONVERTER,
+              "header.converter.schemas.enable",
+              "false",
+              "header.converter.converter.type",
+              "header"));
+
+      SinkRecord record = createRecord(KEY_STRING, VALUE_STRING, headers);
+      SinkRecord result = smt.apply(record);
+      assertThat(result.keySchema()).isNull();
+      assertThat(result.valueSchema()).isEqualTo(ErrorTransform.FAILED_SCHEMA);
+      assertThat(result.valueSchema().name()).isEqualTo("failed_message");
+      assertThat(result.value()).isInstanceOf(Struct.class);
+      Struct value = (Struct) result.value();
+      assertThat(value.get("topic")).isEqualTo(TOPIC);
+      assertThat(value.get("partition")).isEqualTo(PARTITION);
+      assertThat(value.get("offset")).isEqualTo(OFFSET);
+      assertThat(value.get("location")).isEqualTo("HEADER_CONVERTER");
+      assertThat(((String) value.get("stack_trace")).contains("JsonConverter")).isTrue();
+      assertThat(((String) value.get("exception")).contains("DataException")).isTrue();
+      assertThat((byte[]) value.get("key_bytes"))
+          .isEqualTo(KEY_STRING.getBytes(StandardCharsets.UTF_8));
+      assertThat((byte[]) value.get("value_bytes"))
+          .isEqualTo(VALUE_STRING.getBytes(StandardCharsets.UTF_8));
+
+      assertThat(value.get("headers")).isInstanceOf(List.class);
+      List<?> resultHeaders = (ArrayList<?>) (value.get("headers"));
+      assertThat(resultHeaders).isNotEmpty();
+      Struct headerElement = (Struct) resultHeaders.get(0);
+      assertThat(headerElement.get("key")).isEqualTo("h1");
+      assertThat((byte[]) headerElement.get("value"))
+          .isEqualTo(malformedValue.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  @DisplayName("Should return failed SinkRecord if SMT fails")
+  public void smtFailed() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+      smt.configure(
+          ImmutableMap.of(
+              "value.converter",
+              STRING_CONVERTER,
+              "key.converter",
+              STRING_CONVERTER,
+              "header.converter",
+              STRING_CONVERTER,
+              "header.converter.converter.type",
+              "header",
+              "smts",
+              "io.tabular.iceberg.connect.transforms.TestStringTransform,io.tabular.iceberg.connect.transforms.TestStringTransform",
+              "smts.throw",
+              "true"));
+
+      SinkRecord record = createRecord(KEY_STRING, VALUE_STRING, stringAsByteHeaders());
+      SinkRecord result = smt.apply(record);
+      assertThat(result.keySchema()).isNull();
+      assertThat(result.valueSchema()).isEqualTo(ErrorTransform.FAILED_SCHEMA);
+      assertThat(result.valueSchema().name()).isEqualTo("failed_message");
+      assertThat(result.value()).isInstanceOf(Struct.class);
+      Struct value = (Struct) result.value();
+      assertThat(value.get("topic")).isEqualTo(TOPIC);
+      assertThat(value.get("partition")).isEqualTo(PARTITION);
+      assertThat(value.get("offset")).isEqualTo(OFFSET);
+      assertThat(value.get("location")).isEqualTo("SMT_FAILURE");
+      assertThat(((String) value.get("stack_trace")).contains("smt failure")).isTrue();
+      assertThat(((String) value.get("exception")).contains("smt failure")).isTrue();
+      assertThat((byte[]) value.get("key_bytes"))
+          .isEqualTo(KEY_STRING.getBytes(StandardCharsets.UTF_8));
+      assertThat((byte[]) value.get("value_bytes"))
+          .isEqualTo(VALUE_STRING.getBytes(StandardCharsets.UTF_8));
+
+      assertThat(value.get("headers")).isInstanceOf(List.class);
+      List<?> resultHeaders = (ArrayList<?>) (value.get("headers"));
+      assertThat(resultHeaders).isNotEmpty();
+      Struct headerElement = (Struct) resultHeaders.get(0);
+      assertThat(headerElement.get("key")).isEqualTo("h1");
+      assertThat((byte[]) headerElement.get("value"))
+          .isEqualTo("h1".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  @DisplayName("Should throw if runtime classes cannot be dynamically loaded or configured")
+  public void shouldThrowClassLoader() {
+    try (ErrorTransform smt = new ErrorTransform()) {
+      assertThrows(
+          ErrorTransform.TransformInitializationException.class,
+          () -> smt.configure(ImmutableMap.of("value.converter", "")));
+    }
+
+    try (ErrorTransform smt = new ErrorTransform()) {
+      assertThrows(
+          ErrorTransform.TransformInitializationException.class,
+          () -> smt.configure(ImmutableMap.of("value.converter", "some_bogus_class")));
+    }
+
+    try (ErrorTransform smt = new ErrorTransform()) {
+      assertThrows(
+          ErrorTransform.TransformInitializationException.class,
+          () ->
+              smt.configure(
+                  ImmutableMap.of(
+                      "value.converter",
+                      STRING_CONVERTER,
+                      "key.converter",
+                      STRING_CONVERTER,
+                      "header.converter",
+                      "some_bogus_class",
+                      "header.converter.converter.type",
+                      "header",
+                      "smts",
+                      "io.tabular.iceberg.connect.transforms.TestStringTransform,io.tabular.iceberg.connect.transforms.TestStringTransform",
+                      "smts.throw",
+                      "true")));
+    }
+
+    try (ErrorTransform smt = new ErrorTransform()) {
+      assertThrows(
+          ErrorTransform.TransformInitializationException.class,
+          () ->
+              smt.configure(
+                  ImmutableMap.of(
+                      "value.converter",
+                      STRING_CONVERTER,
+                      "key.converter",
+                      STRING_CONVERTER,
+                      "header.converter",
+                      STRING_CONVERTER,
+                      "header.converter.converter.type",
+                      "header",
+                      "smts",
+                      "some_bogus_smt",
+                      "smts.throw",
+                      "true")));
+    }
+    try (ErrorTransform smt = new ErrorTransform()) {
+      // throws because the header converter fails when .configure is called
+      assertThrows(
+          ErrorTransform.TransformInitializationException.class,
+          () ->
+              smt.configure(
+                  ImmutableMap.of(
+                      "value.converter",
+                      STRING_CONVERTER,
+                      "key.converter",
+                      STRING_CONVERTER,
+                      "header.converter",
+                      STRING_CONVERTER)));
+    }
+  }
+
+  @Test
+  @DisplayName("PropsParser should return an empty map for keys that do not match target")
+  public void propsParserEmptyMap() {
+    Map<String, String> input = ImmutableMap.of("some.key", "some.value");
+    assertThat(ErrorTransform.PropsParser.apply(input, "missing")).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "PropsParser should return Map with keys matching target stripped of the target prefix")
+  public void keysMatching() {
+    Map<String, String> input =
+        ImmutableMap.of("value.converter", "some.class.here", "value.converter.prop", "some.prop");
+    assertThat(ErrorTransform.PropsParser.apply(input, "value.converter"))
+        .isEqualTo(ImmutableMap.of("prop", "some.prop"));
+  }
+}

--- a/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/TestStringTransform.java
+++ b/kafka-connect-transforms/src/test/java/io/tabular/iceberg/connect/transforms/TestStringTransform.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transforms;
+
+import java.util.Map;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+
+/* Appends values to record.values that are strings, useful for testing SMT control flow */
+public class TestStringTransform implements Transformation<SinkRecord> {
+
+  private String text;
+  private boolean returnNull;
+
+  private boolean shouldThrow;
+
+  @Override
+  public synchronized SinkRecord apply(SinkRecord record) {
+    if (shouldThrow) {
+      throw new RuntimeException("smt failure");
+    }
+    if (record.value() == null) {
+      return record;
+    }
+    if (returnNull) {
+      return null;
+    }
+    String newValue;
+    if (record.value() instanceof String) {
+      newValue = (record.value()) + text;
+    } else {
+      throw new IllegalArgumentException("record.value is not a string");
+    }
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        record.valueSchema(),
+        newValue,
+        record.timestamp());
+  }
+
+  @Override
+  public ConfigDef config() {
+    return new ConfigDef();
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> map) {
+    if (map.get("transform_text") != null) {
+      text = (String) map.get("transform_text");
+    } else {
+      text = "default";
+    }
+
+    if (map.get("null") != null) {
+      returnNull = Boolean.parseBoolean((String) map.get("null"));
+    } else {
+      returnNull = false;
+    }
+
+    if (map.get("throw") != null) {
+      shouldThrow = Boolean.parseBoolean((String) map.get("throw"));
+    } else {
+      shouldThrow = false;
+    }
+  }
+}

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
   implementation project(":iceberg-kafka-connect-events")
+  implementation project(":iceberg-kafka-connect-deadletter")
   implementation libs.bundles.iceberg
   implementation libs.bundles.jackson
   implementation libs.avro

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -83,12 +83,7 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.schema-force-optional";
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
-  private static final String USE_DEAD_LETTER_TABLE_PROP = "iceberg.tables.deadletter";
-  private static final String DEAD_LETTER_TABLE_SUFFIX_PROP = "iceberg.tables.deadletter.suffix";
-  private static final String DEAD_LETTER_TABLE_SUFFIX_DEFAULT = "__dlt";
-
-  private static final String DEAD_LETTER_TABLE_NAMESPACE = "iceberg.tables.deadletter.namespace";
-  private static final String DEAD_LETTER_TABLE_NAMESPACE_DEFAULT = "dead_letter";
+  private static final String DEAD_LETTER_TABLE_PROP = "iceberg.tables.deadletter";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PROP = "iceberg.control.group-id";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -244,23 +239,11 @@ public class IcebergSinkConfig extends AbstractConfig {
         Importance.MEDIUM,
         "Coordinator threads to use for table commits, default is (cores * 2)");
     configDef.define(
-        USE_DEAD_LETTER_TABLE_PROP,
-        Type.BOOLEAN,
-        false,
-        Importance.MEDIUM,
-        "Handle dead letter table payloads. Must use ErrorTransform SMT");
-    configDef.define(
-        DEAD_LETTER_TABLE_SUFFIX_PROP,
+        DEAD_LETTER_TABLE_PROP,
         Type.STRING,
-        DEAD_LETTER_TABLE_SUFFIX_DEFAULT,
+        null,
         Importance.MEDIUM,
-        "If using dead letter table, suffix to append to table to generate dead letter table name");
-    configDef.define(
-        DEAD_LETTER_TABLE_NAMESPACE,
-        Type.STRING,
-        DEAD_LETTER_TABLE_NAMESPACE_DEFAULT,
-        Importance.MEDIUM,
-        "If using dead letter table, namespace to put the tables with undetermined destination");
+        "If using ErrorTransform for Dead Letter Table, the db.name to write");
     return configDef;
   }
 
@@ -358,15 +341,12 @@ public class IcebergSinkConfig extends AbstractConfig {
   }
 
   public boolean deadLetterTableEnabled() {
-    return getBoolean(USE_DEAD_LETTER_TABLE_PROP);
+    String table = getString(DEAD_LETTER_TABLE_PROP);
+    return table != null;
   }
 
-  public String deadLetterTableSuffix() {
-    return getString(DEAD_LETTER_TABLE_SUFFIX_PROP);
-  }
-
-  public String deadLetterTopicNamespace() {
-    return getString(DEAD_LETTER_TABLE_NAMESPACE);
+  public String deadLetterTableName() {
+    return getString(DEAD_LETTER_TABLE_PROP);
   }
 
   public String tablesRouteField() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -83,6 +83,8 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.schema-force-optional";
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
+  private static final String DEAD_LETTER_TABLE_SUFFIX_PROP = "iceberg.tables.deadletter.suffix";
+  private static final String DEAD_LETTER_TABLE_SUFFIX_DEFAULT = "__dlt";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PROP = "iceberg.control.group-id";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -336,6 +338,11 @@ public class IcebergSinkConfig extends AbstractConfig {
   // TODO
   public boolean deadLetterTableEnabled() {
     return false;
+  }
+
+  // TODO handle the default
+  public String deadLetterTableSuffix() {
+    return getString(DEAD_LETTER_TABLE_SUFFIX_PROP);
   }
 
   public String tablesRouteField() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -333,6 +333,11 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getBoolean(TABLES_DYNAMIC_PROP);
   }
 
+  // TODO
+  public boolean deadLetterTableEnabled() {
+    return false;
+  }
+
   public String tablesRouteField() {
     return getString(TABLES_ROUTE_FIELD_PROP);
   }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -83,8 +83,12 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.schema-force-optional";
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
+  private static final String USE_DEAD_LETTER_TABLE_PROP = "iceberg.tables.deadletter";
   private static final String DEAD_LETTER_TABLE_SUFFIX_PROP = "iceberg.tables.deadletter.suffix";
   private static final String DEAD_LETTER_TABLE_SUFFIX_DEFAULT = "__dlt";
+
+  private static final String DEAD_LETTER_TABLE_NAMESPACE = "iceberg.tables.deadletter.namespace";
+  private static final String DEAD_LETTER_TABLE_NAMESPACE_DEFAULT = "dead_letter";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PROP = "iceberg.control.group-id";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -239,6 +243,24 @@ public class IcebergSinkConfig extends AbstractConfig {
         null,
         Importance.MEDIUM,
         "Coordinator threads to use for table commits, default is (cores * 2)");
+    configDef.define(
+        USE_DEAD_LETTER_TABLE_PROP,
+        Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        "Handle dead letter table payloads. Must use ErrorTransform SMT");
+    configDef.define(
+        DEAD_LETTER_TABLE_SUFFIX_PROP,
+        Type.STRING,
+        DEAD_LETTER_TABLE_SUFFIX_DEFAULT,
+        Importance.MEDIUM,
+        "If using dead letter table, suffix to append to table to generate dead letter table name");
+    configDef.define(
+        DEAD_LETTER_TABLE_NAMESPACE,
+        Type.STRING,
+        DEAD_LETTER_TABLE_NAMESPACE_DEFAULT,
+        Importance.MEDIUM,
+        "If using dead letter table, namespace to put the tables with undetermined destination");
     return configDef;
   }
 
@@ -335,14 +357,16 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getBoolean(TABLES_DYNAMIC_PROP);
   }
 
-  // TODO
   public boolean deadLetterTableEnabled() {
-    return false;
+    return getBoolean(USE_DEAD_LETTER_TABLE_PROP);
   }
 
-  // TODO handle the default
   public String deadLetterTableSuffix() {
     return getString(DEAD_LETTER_TABLE_SUFFIX_PROP);
+  }
+
+  public String deadLetterTopicNamespace() {
+    return getString(DEAD_LETTER_TABLE_NAMESPACE);
   }
 
   public String tablesRouteField() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -93,6 +93,9 @@ public class Worker extends Channel {
 
     @Override
     public void write(String tableName, SinkRecord sample, boolean ignoreMissingTable) {
+      // TODO 
+      // dig out the correct part of the message here based on the dead letter table shape
+
       RecordWriter writer = writers.computeIfAbsent(
               tableName, notUsed -> writerFactory.createWriter(tableName, sample, ignoreMissingTable));
       try {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -239,17 +239,10 @@ public class Worker extends Channel {
 
     private final RouteExtractor extractor;
 
-    private final String deadLetterNamespace;
-
-    StaticRecordRouter(
-        WriterForTable writerForTable,
-        String routeField,
-        RouteExtractor extractor,
-        String deadLetterNamespace) {
+    StaticRecordRouter(WriterForTable writerForTable, String routeField, RouteExtractor extractor) {
       this.writerForTable = writerForTable;
       this.routeField = routeField;
       this.extractor = extractor;
-      this.deadLetterNamespace = deadLetterNamespace;
     }
 
     @Override
@@ -278,17 +271,11 @@ public class Worker extends Channel {
     private final String routeField;
     private final RouteExtractor extractor;
 
-    private final String deadLetterNamespace;
-
     DynamicRecordRouter(
-        WriterForTable writerForTable,
-        String routeField,
-        RouteExtractor extractor,
-        String deadLetterNamespace) {
+        WriterForTable writerForTable, String routeField, RouteExtractor extractor) {
       this.writerForTable = writerForTable;
       this.routeField = routeField;
       this.extractor = extractor;
-      this.deadLetterNamespace = deadLetterNamespace;
     }
 
     @Override
@@ -334,21 +321,13 @@ public class Worker extends Channel {
       Preconditions.checkNotNull(
           config.tablesRouteField(), "Route field cannot be null with dynamic routing");
       baseRecordRouter =
-          new DynamicRecordRouter(
-              writerForTable,
-              config.tablesRouteField(),
-              routeExtractor,
-              config.deadLetterTopicNamespace());
+          new DynamicRecordRouter(writerForTable, config.tablesRouteField(), routeExtractor);
     } else {
       if (config.tablesRouteField() == null) {
         baseRecordRouter = new ConfigRecordRouter(writerForTable);
       } else {
         baseRecordRouter =
-            new StaticRecordRouter(
-                writerForTable,
-                config.tablesRouteField(),
-                routeExtractor,
-                config.deadLetterTopicNamespace());
+            new StaticRecordRouter(writerForTable, config.tablesRouteField(), routeExtractor);
       }
     }
     if (config.deadLetterTableEnabled()) {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -59,15 +59,13 @@ public class IcebergWriter implements RecordWriter {
   public void write(SinkRecord record) {
     try {
       // TODO: config to handle tombstones instead of always ignoring?
-      if (record.value() != null) {
-        Record row = convertToRow(record);
-        String cdcField = config.tablesCdcField();
-        if (cdcField == null) {
-          writer.write(row);
-        } else {
-          Operation op = extractCdcOperation(record.value(), cdcField);
-          writer.write(new RecordWrapper(row, op));
-        }
+      Record row = convertToRow(record);
+      String cdcField = config.tablesCdcField();
+      if (cdcField == null) {
+        writer.write(row);
+      } else {
+        Operation op = extractCdcOperation(record.value(), cdcField);
+        writer.write(new RecordWrapper(row, op));
       }
     } catch (Exception e) {
       throw new DataException(

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.data.IcebergWriter;
 import io.tabular.iceberg.connect.data.IcebergWriterFactory;
+import io.tabular.iceberg.connect.data.RecordWriter;
 import io.tabular.iceberg.connect.data.WriterResult;
 import io.tabular.iceberg.connect.events.CommitReadyPayload;
 import io.tabular.iceberg.connect.events.CommitRequestPayload;
@@ -33,17 +34,20 @@ import io.tabular.iceberg.connect.events.CommitResponsePayload;
 import io.tabular.iceberg.connect.events.Event;
 import io.tabular.iceberg.connect.events.EventTestUtil;
 import io.tabular.iceberg.connect.events.EventType;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class WorkerTest extends ChannelTestBase {
@@ -115,5 +119,34 @@ public class WorkerTest extends ChannelTestBase {
     assertThat(readyPayload.assignments()).hasSize(1);
     // offset should be one more than the record offset
     assertThat(readyPayload.assignments().get(0).offset()).isEqualTo(1L);
+  }
+
+  private static class RecordingRecordWriter implements RecordWriter {
+    List<SinkRecord> seen = Lists.newArrayList();
+
+    public void write(SinkRecord record) {
+      seen.add(record);
+    }
+  }
+
+  @Test
+  @DisplayName("DeadLetterWriterForTable should handle custom ErrorTransform payloads")
+  public void deadLetterWriterForTable() {
+    //    RecordWriter writer = new RecordingRecordWriter();
+    //
+    //    IcebergWriterFactory writerFactory = mock(IcebergWriterFactory.class);
+    //    when(writerFactory.createWriter(any(), any(), anyBoolean())).thenReturn(writer);
+    //
+    //    Map<String, RecordWriter> writerMap = Maps.newHashMap();
+    //
+    //    Worker.DeadLetterWriterForTable writerForTable = new Worker.DeadLetterWriterForTable(
+    //            writerFactory,
+    //            writerMap,
+    //            config
+    //    );
+    //
+    //    SinkRecord nullRecord = new SinkRecord(SRC_TOPIC_NAME, 0, null, null, null, null, 0);
+    //    writerForTable.write(, );
+
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,6 @@ project(":iceberg-kafka-connect-transforms").projectDir = file("kafka-connect-tr
 
 include "iceberg-kafka-connect-runtime"
 project(":iceberg-kafka-connect-runtime").projectDir = file("kafka-connect-runtime")
+
+include "iceberg-kafka-connect-deadletter"
+project(":iceberg-kafka-connect-deadletter").projectDir = file("kafka-connect-deadletter")


### PR DESCRIPTION
Implements a dead letter table where failed messages go to a dedicated Iceberg table.  This functionality aims to improve and simplify the error handling provided by Kafka Connect.  Kafka Connect's dead letter queue only handles deserialization and SMT failures and writes to another Kafka Connect topic where it requires additional engineering effort to inspect and recover messages.   Instead, errors are written to a dedicated Iceberg Table where messages can be inspected and recovered using tools users may be more comfortable with (Spark, etc).  The resulting contain everything in order to process a row back into a Kafka `ProducerRecord`.

|Location of Failure | Kafka Connect DLQ | This PR | 
|-------------------|---------------------|---------|
| Deserialization/Converter.     |  Yes | Yes | 
| SMT | Yes | Yes | 
| Table creation / schema issues | No | Yes | 
| Iceberg record conversion | No | Yes | 
| Malformed records (e.g. missing table route information) | No | Yes | 
| Schema evolution issues | No | Yes | 

This PR aims to minimize stream processing exceptions from imperfect producers by writing to the Dead Letter Table rather than failing constantly and causing rebalances inside of the Kafka Cluster which can negatively affect other jobs. 

It is comprised of two components: 

1. An ErrorTransform SMT that wraps the Deserializer and zero or more SMTs 
2. Changes to `Worker.java` / `IcebergWriterFactory.java` to catch issues around table creation, schema parsing, and Iceberg record conversion 

## Error Transform 

Kafka Connects `value`, `key`, and `header` converters must be `ByteArrayConverters`.  The desired converters (`AvroConverter`, `JsonConverter`, etc.) are supplied to the `ErrorTransform` SMT along with any other SMTs.  

* On deserialization success and SMT transformation success:  A special record containing a `Map<String, Object>` is constructed that contains the deserialized and transformed `SinkRecord` as well as the original key, value, and header bytes of the message. 
* On deserialization failure OR SMT transformation failure:  a `SinkRecord` of `Struct` is created containing failure metadata such as kafka metadata, exception, stack trace, and original key, value, and header bytes. 

## Changes to `Worker.java` / `IcebergWriterFactory.java` 

When configured to use the `DeadLetterTable` the connector expects to messages to be in the shape of the data from the `ErrorTransform` SMT.  Failed records from the SMT will be written to the Dead Letter Table.  Successfully transformed SinkRecords will attempt the normal connector flow.  If it fails for non-transient reasons, the original key, value, and header bytes in the specially transformed record are used to construct a `SinkRecord` for the Dead Letter Table with the required Kafka and error metadata before being written via normal table fanout. 

## Limitations 

This is the first PR.  Additional work is required for some advanced Converters such as the `AvroConverter`, where finely grained exception handling needs to be implemented to differentiate between real Avro errors (e.g. the message is not valid Avro bytes or the message does not have an entry in the Schema registry) and network related Avro exceptions (e.g. contacting the Schema registry times out).  This is planned in future PRs. 

