### PR TITLE
Add Kerberos authentication option

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   implementation libs.bundles.jackson
   implementation libs.avro
   implementation libs.slf4j
+  implementation libs.hadoop.client
   compileOnly libs.bundles.kafka.connect
 
   testImplementation(testFixtures(project(":iceberg-kafka-connect-events")))

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -93,6 +93,17 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String CONNECT_GROUP_ID_PROP = "iceberg.connect.group-id";
   private static final String HADDOP_CONF_DIR_PROP = "iceberg.hadoop-conf-dir";
 
+  private static final String HDFS_AUTHENTICATION_KERBEROS_PROP =
+      "iceberg.hdfs.authentication.kerberos";
+  private static final Boolean HDFS_AUTHENTICATION_KERBEROS_DEFAULT = false;
+  private static final String CONNECT_HDFS_PRINCIPAL_PROP = "iceberg.connect.hdfs.principal";
+  private static final String CONNECT_HDFS_PRINCIPAL_DEFAULT = "";
+  private static final String CONNECT_HDFS_KEYTAB_PROP = "iceberg.connect.hdfs.keytab";
+  private static final String CONNECT_HDFS_KEYTAB_DEFAULT = "";
+  private static final String KERBEROS_TICKET_RENEW_PERIOD_MS_PROP =
+      "kerberos.ticket.renew.period.ms";
+  private static final long KERBEROS_TICKET_RENEW_PERIOD_MS_DEFAULT = 60000 * 60;
+
   private static final String NAME_PROP = "name";
   private static final String BOOTSTRAP_SERVERS_PROP = "bootstrap.servers";
 
@@ -213,6 +224,30 @@ public class IcebergSinkConfig extends AbstractConfig {
         null,
         Importance.LOW,
         "Name of the Connect consumer group, should not be set under normal conditions");
+    configDef.define(
+        HDFS_AUTHENTICATION_KERBEROS_PROP,
+        Type.BOOLEAN,
+        HDFS_AUTHENTICATION_KERBEROS_DEFAULT,
+        Importance.HIGH,
+        "Configuration indicating whether HDFS is using Kerberos for authentication");
+    configDef.define(
+        CONNECT_HDFS_PRINCIPAL_PROP,
+        Type.STRING,
+        CONNECT_HDFS_PRINCIPAL_DEFAULT,
+        Importance.HIGH,
+        "The principal name to load from the keytab for Kerberos authentication");
+    configDef.define(
+        CONNECT_HDFS_KEYTAB_PROP,
+        Type.STRING,
+        CONNECT_HDFS_KEYTAB_DEFAULT,
+        Importance.HIGH,
+        "The path to the keytab file for the HDFS connector principal. This keytab file should only be readable by the connector user");
+    configDef.define(
+        KERBEROS_TICKET_RENEW_PERIOD_MS_PROP,
+        Type.LONG,
+        KERBEROS_TICKET_RENEW_PERIOD_MS_DEFAULT,
+        Importance.LOW,
+        "The period in milliseconds to renew the Kerberos ticket");
     configDef.define(
         COMMIT_INTERVAL_MS_PROP,
         Type.INT,
@@ -409,6 +444,22 @@ public class IcebergSinkConfig extends AbstractConfig {
     String connectorName = connectorName();
     Preconditions.checkNotNull(connectorName, "Connector name cannot be null");
     return "connect-" + connectorName;
+  }
+
+  public boolean kerberosAuthentication() {
+    return getBoolean(HDFS_AUTHENTICATION_KERBEROS_PROP);
+  }
+
+  public String connectHdfsPrincipal() {
+    return getString(CONNECT_HDFS_PRINCIPAL_PROP);
+  }
+
+  public String connectHdfsKeytab() {
+    return getString(CONNECT_HDFS_KEYTAB_PROP);
+  }
+
+  public long kerberosTicketRenewPeriodMs() {
+    return getLong(KERBEROS_TICKET_RENEW_PERIOD_MS_PROP);
   }
 
   public int commitIntervalMs() {


### PR DESCRIPTION
Hello,
I was going to use this connector for hdfs, but I noticed it does not support Kerberos authentication.
To address this, I added Kerberos authentication functionality along with other related options.
In implementing this feature, I have used the existing [hdfs sink connector](https://github.com/confluentinc/kafka-connect-hdfs) codes as a reference, which already does support Kerberos authentication. ([document link](https://docs.confluent.io/kafka-connectors/hdfs/current/configuration_options.html#security))

The example config would look like
```
iceberg.hdfs.authentication.kerberos: true,
iceberg.connect.hdfs.principal: "user@EXAMPLE.COM",
iceberg.connect.hdfs.keytab: "/tmp/user.keytab",
kerberos.ticket.renew.period.ms: 3600000
```

I understand there should be further tasks such as updating README and adding some test codes, but I wanted to share the core idea with you first for initial feedback.
Please take a look. Thank you.