### PR TITLE
Add WriteExceptionHandler

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -96,6 +96,9 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String NAME_PROP = "name";
   private static final String BOOTSTRAP_SERVERS_PROP = "bootstrap.servers";
 
+  private static final String WRITE_EXCEPTION_HANDLER_CLASS_PROP =
+      "experimental.write-exception-handler.class";
+
   private static final String DEFAULT_CATALOG_NAME = "iceberg";
   private static final String DEFAULT_CONTROL_TOPIC = "control-iceberg";
   public static final String DEFAULT_CONTROL_GROUP_PREFIX = "cg-control-";
@@ -237,6 +240,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         null,
         Importance.MEDIUM,
         "Coordinator threads to use for table commits, default is (cores * 2)");
+    configDef.define(
+        WRITE_EXCEPTION_HANDLER_CLASS_PROP,
+        Type.STRING,
+        null,
+        Importance.MEDIUM,
+        "The WriteExceptionHandler implementation to use to handle exceptions when writing records to files");
     return configDef;
   }
 
@@ -449,6 +458,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public JsonConverter jsonConverter() {
     return jsonConverter;
+  }
+
+  public String writeExceptionHandlerClassName() {
+    return getString(WRITE_EXCEPTION_HANDLER_CLASS_PROP);
   }
 
   private Map<String, String> loadWorkerProps() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/WriteExceptionHandler.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/WriteExceptionHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+
+public interface WriteExceptionHandler {
+  void initialize(SinkTaskContext context, IcebergSinkConfig config);
+
+  class Result {
+    private final SinkRecord sinkRecord;
+    private final String tableName;
+
+    public Result(SinkRecord sinkRecord, String tableName) {
+      this.sinkRecord = sinkRecord;
+      this.tableName = tableName;
+    }
+
+    public SinkRecord sinkRecord() {
+      return sinkRecord;
+    }
+
+    public String tableName() {
+      return tableName;
+    }
+  }
+
+  /**
+   * This method will be invoked whenever the connector runs into an exception while trying to write
+   * SinkRecords to a table. Implementations of this method have 3 general options:
+   *
+   * <ol>
+   *   <li>Return a SinkRecord and the name of the table to write to (wrapped inside a {@link
+   *       Result})
+   *   <li>Return null to drop the SinkRecord
+   *   <li>Throw an exception to fail the task
+   * </ol>
+   *
+   * @param sinkRecord The SinkRecord that couldn't be written
+   * @param tableName The table the SinkRecord couldn't be written to
+   * @param exception The exception encountered while trying to write the SinkRecord
+   */
+  Result handle(SinkRecord sinkRecord, String tableName, Exception exception) throws Exception;
+
+  /**
+   * This method will be invoked prior to committing allowing advanced {@link WriteExceptionHandler}
+   * implementations to complete any inflight work before the connector commits.
+   *
+   * <p>Note that there is no guarantee that the connector will successfully commit after this
+   * method is called.
+   */
+  void preCommit();
+}

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/ExceptionHandlingTableWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/ExceptionHandlingTableWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.channel;
+
+import io.tabular.iceberg.connect.WriteExceptionHandler;
+import io.tabular.iceberg.connect.data.Utilities;
+import io.tabular.iceberg.connect.data.WriterResult;
+import java.util.List;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+class ExceptionHandlingTableWriter implements TableWriter, AutoCloseable {
+
+  private final TableWriter underlying;
+  private final WriteExceptionHandler exceptionHandler;
+
+  ExceptionHandlingTableWriter(TableWriter underlying, WriteExceptionHandler exceptionHandler) {
+    this.underlying = underlying;
+    this.exceptionHandler = exceptionHandler;
+  }
+
+  @Override
+  public void write(SinkRecord sinkRecord, String tableName, boolean ignoreMissingTable) {
+    try {
+      underlying.write(sinkRecord, tableName, ignoreMissingTable);
+    } catch (Exception exception) {
+      final WriteExceptionHandler.Result result;
+      try {
+        result = exceptionHandler.handle(sinkRecord, tableName, exception);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+
+      if (result != null) {
+        // TODO: ignoreMissingTables=false make sense here? I _think_ so but I could also expose
+        // it
+        write(result.sinkRecord(), result.tableName(), false);
+      }
+    }
+  }
+
+  @Override
+  public List<WriterResult> committable() {
+    exceptionHandler.preCommit();
+    return underlying.committable();
+  }
+
+  @Override
+  public void close() {
+    Utilities.close(exceptionHandler);
+    Utilities.close(underlying);
+  }
+}

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/MultiTableWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/MultiTableWriter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.channel;
+
+import io.tabular.iceberg.connect.data.IcebergWriterFactory;
+import io.tabular.iceberg.connect.data.RecordWriter;
+import io.tabular.iceberg.connect.data.Utilities;
+import io.tabular.iceberg.connect.data.WriterResult;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+class MultiTableWriter implements TableWriter, AutoCloseable {
+
+  private final IcebergWriterFactory writerFactory;
+  private final Map<String, RecordWriter> writers;
+
+  MultiTableWriter(IcebergWriterFactory writerFactory) {
+    this.writerFactory = writerFactory;
+    this.writers = Maps.newHashMap();
+  }
+
+  private RecordWriter writerForTable(
+      String tableName, SinkRecord sample, boolean ignoreMissingTable) {
+    return writers.computeIfAbsent(
+        tableName, notUsed -> writerFactory.createWriter(tableName, sample, ignoreMissingTable));
+  }
+
+  @Override
+  public void write(SinkRecord sinkRecord, String tableName, boolean ignoreMissingTable) {
+    writerForTable(tableName, sinkRecord, ignoreMissingTable).write(sinkRecord);
+  }
+
+  private void closeWriters() {
+    writers.values().forEach(Utilities::close);
+    writers.clear();
+  }
+
+  @Override
+  public List<WriterResult> committable() {
+    List<WriterResult> writerResults =
+        writers.values().stream()
+            .flatMap(writer -> writer.complete().stream())
+            .collect(Collectors.toList());
+
+    closeWriters();
+
+    return writerResults;
+  }
+
+  @Override
+  public void close() {
+    closeWriters();
+    Utilities.close(writerFactory);
+  }
+}

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/TableWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/TableWriter.java
@@ -16,17 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.tabular.iceberg.connect.data;
+package io.tabular.iceberg.connect.channel;
 
+import io.tabular.iceberg.connect.data.WriterResult;
 import java.util.List;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public interface RecordWriter {
+interface TableWriter {
+  void write(SinkRecord sinkRecord, String tableName, boolean ignoreMissingTable);
 
-  default void write(SinkRecord record) {}
-
-  default List<WriterResult> complete() {
-    return ImmutableList.of();
-  }
+  List<WriterResult> committable();
 }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/TableWriterImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/TableWriterImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.channel;
+
+import io.tabular.iceberg.connect.IcebergSinkConfig;
+import io.tabular.iceberg.connect.WriteExceptionHandler;
+import io.tabular.iceberg.connect.data.IcebergWriterFactory;
+import io.tabular.iceberg.connect.data.Utilities;
+import io.tabular.iceberg.connect.data.WriterResult;
+import java.util.List;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+
+class TableWriterImpl implements TableWriter, AutoCloseable {
+
+  private final TableWriter underlying;
+
+  private WriteExceptionHandler loadHandler(String name) {
+    ClassLoader loader = this.getClass().getClassLoader();
+    final Object obj;
+    try {
+      Class<?> clazz = Class.forName(name, true, loader);
+      obj = clazz.getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(String.format("Could not initialize class %s", name), e);
+    }
+
+    final WriteExceptionHandler writeExceptionHandler = (WriteExceptionHandler) obj;
+
+    return writeExceptionHandler;
+  }
+
+  TableWriterImpl(
+      SinkTaskContext context, IcebergSinkConfig config, IcebergWriterFactory writerFactory) {
+    MultiTableWriter baseTableWriter = new MultiTableWriter(writerFactory);
+    if (config.writeExceptionHandlerClassName() == null) {
+      this.underlying = baseTableWriter;
+    } else {
+      WriteExceptionHandler handler = loadHandler(config.writeExceptionHandlerClassName());
+      handler.initialize(context, config);
+      this.underlying = new ExceptionHandlingTableWriter(baseTableWriter, handler);
+    }
+  }
+
+  @Override
+  public void write(SinkRecord sinkRecord, String tableName, boolean ignoreMissingTable) {
+    underlying.write(sinkRecord, tableName, ignoreMissingTable);
+  }
+
+  @Override
+  public List<WriterResult> committable() {
+    return underlying.committable();
+  }
+
+  @Override
+  public void close() {
+    Utilities.close(underlying);
+  }
+}

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public class IcebergWriter implements RecordWriter {
+public class IcebergWriter implements RecordWriter, AutoCloseable {
   private final Table table;
   private final String tableName;
   private final IcebergSinkConfig config;

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
@@ -264,5 +264,20 @@ public class Utilities {
     return configClass;
   }
 
+  public static <C> void close(C closeable) {
+    if (closeable != null) {
+      if (closeable instanceof AutoCloseable) {
+        try {
+          ((AutoCloseable) closeable).close();
+        } catch (Exception e) {
+          LOG.warn(
+              "An error occurred while trying to close {} instance, ignoring...",
+              closeable.getClass().getSimpleName(),
+              e);
+        }
+      }
+    }
+  }
+
   private Utilities() {}
 }


### PR DESCRIPTION
Adds a configuration option to specify a `WriteExceptionHandler` to use to handle any exceptions while writing SinkRecords to files. 

I haven't tested any of this yet :D but in theory: 
- Exceptions happening within `SinkTask.put` would be captured by the user configured `WriteExceptionHandler` and handled there. 
- Converter/SMT exceptions (i.e. things before `SinkTask.put`), users should configure the connector in `iceberg.tables.dynamic-enabled` with a `iceberg.tables.route-field` and write an exception-handling-SMT that points to the the dead-letter-table. 
- We should provide sample implementations of `WriteExceptionHandler` and an `ExceptionHandlingSMT` that should work for 90% of usecases. 

# Pros

1. Doesn't require a specific schema for dead-letter tables
    - The nice thing here is users can have **_any_** schema for their "dead-letter" table
    - If you only want to write out topic, partition, and offset, you can
    - If you want to write out keys and values as `byte[]`, you can 
    - If you want to write out keys and values as JSON, you can
1. Doesn't limit you to a single dead-letter-table per connector
    - Users can have as many or as few dead letter tables as they want, just write an appropriate handler to do it
    - E.g. if a user wants a dead-letter-table per topic, users can just write a `WriteExceptionHandler` that sends bads record from different topics to different tables. 
1. The connector code remains completely oblivious to Converter/SMT failures
1. Users have fine-grained control over which exceptions to handle (or not)
1. Similarly, we (maintainers) don't have to worry about adding exception handling code to the connector
    - I'm particularly worried about REST catalogs which only really have a REST spec. There is no guarantee an exception thrown by one REST Catalog is non-transient versus another. 
1. Users aren't forced to write bad records to an iceberg table
    - Although I expect this feature to be used mostly for writing bad records to an iceberg table, it's not compulsory
    - Some users might want to write to Kafka and this is easy to do in Kafka Connect via the `SinkTaskContext.errantRecordReporter.report` API
    - Users are also welcome to write to other systems (e.g. Redis, logs etc.) via a custom WriteExceptionHandler implementation
1. Relatively straight-forward change to the codebase
1. Minor: Doesn't require a specific record structure (isFailed parameter, PAYLOAD_KEY, etc.) for all records in "dead-letter-table mode" (unless the user needs it for their `WriteExceptionHandler` implementation)
   1. This is minor because I imagine that at least 50% of use cases will want this but I still think we can do better than isFailed parameter and PAYLOAD_KEY and things. 

# Cons

1. If users want to write Converter/SMT failures to dead-letter-table, they need to use the connector in dynamic
    - Dynamic mode as it's implemented today only allows you to write to one table at a time i.e. no table fanout. 
    - However, we should be able to alleviate this issue by allowing users to provide a comma-separated list of tables in the route field (im not sure why this wasn't done in the first place so we should double check here). This should be a separate PR though. 
    - Even if we can't alleviate this issue, I'm happy to accept this as a compromise (since the semantics are gonna be a little weird with multiple tables involved) but that's debatable. 
    - @ajreid21 had another good idea on addressing the dynamic-mode constraint here. We could potentially change the connector a little bit so that in dynamic mode, it defaults to looking at the route-field but if the route field doesn't exist, it could fall back to some statically defined values (just like in static mode). 
1. Users have to write a correct `WriteExceptionHandler` implementation
    - We can mitigate this by writing a sample `WriteExceptionHanlder` implementation, similar to how we provide sample SMT implementations already
1. Users have to make sure their `WriteExceptionHandler` implementation is available on the classpath
    - Users already have to make sure that Converter/SMT implementations are available on the classpath so this shouldn't be anything new to most users
    - If we really wanted to, we could include some `WriteExceptionHandler` implementations in the kafka-connect-iceberg project (but we should get some stable implementations first)

# How to <insert-use-case>

It might be a little hard to see how people could use this feature for specific use cases so I've prepared a separate draft PR to show this: https://github.com/tabular-io/iceberg-kafka-connect/pull/244