### PR TITLE
DRAFT: Dead letter implementations

### DIFF
--- a/kafka-connect-exception-handlers/build.gradle
+++ b/kafka-connect-exception-handlers/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id "java-test-fixtures"
+}
+
+dependencies {
+    compileOnly project(":iceberg-kafka-connect")
+    compileOnly libs.bundles.kafka.connect
+
+    testImplementation libs.junit.api
+    testRuntimeOnly libs.junit.engine
+
+    testImplementation libs.assertj
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/kafka-connect-exception-handlers/src/main/java/io/tabular/iceberg/connect/DeadLetterTable.java
+++ b/kafka-connect-exception-handlers/src/main/java/io/tabular/iceberg/connect/DeadLetterTable.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public class DeadLetterTable {
+
+  private DeadLetterTable() {}
+
+  public static final String NAME = "dead-letter";
+
+  public static final Schema SCHEMA =
+      // This is just a simple dead letter table schema just for demonstration purposes
+      // Users can get as complicated as they wish
+      SchemaBuilder.struct()
+          .field("topic", Schema.STRING_SCHEMA)
+          .field("partition", Schema.INT32_SCHEMA)
+          .field("offset", Schema.INT64_SCHEMA)
+          .field("exception", Schema.STRING_SCHEMA)
+          .field("target_table", Schema.STRING_SCHEMA)
+          .schema();
+
+  public static SinkRecord sinkRecord(
+      SinkRecord original, Exception exception, String deadLetterTableName) {
+    Struct struct = new Struct(SCHEMA);
+    struct.put("topic", original.topic());
+    struct.put("partition", original.kafkaPartition());
+    struct.put("offset", original.kafkaOffset());
+    struct.put("exception", exception.toString());
+    struct.put("target_table", deadLetterTableName);
+    return original.newRecord(
+        original.topic(),
+        original.kafkaPartition(),
+        null,
+        null,
+        SCHEMA,
+        struct,
+        original.timestamp());
+  }
+}

--- a/kafka-connect-exception-handlers/src/main/java/io/tabular/iceberg/connect/handler/IcebergDLQ.java
+++ b/kafka-connect-exception-handlers/src/main/java/io/tabular/iceberg/connect/handler/IcebergDLQ.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.handler;
+
+import io.tabular.iceberg.connect.DeadLetterTable;
+import io.tabular.iceberg.connect.IcebergSinkConfig;
+import io.tabular.iceberg.connect.WriteExceptionHandler;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+
+/** Sample DLQ implementation that sends records to a fixed dead-letter table. */
+public class IcebergDLQ implements WriteExceptionHandler {
+  @Override
+  public void initialize(SinkTaskContext context, IcebergSinkConfig config) {}
+
+  @Override
+  public Result handle(SinkRecord sinkRecord, String tableName, Exception exception) {
+    return new WriteExceptionHandler.Result(
+        // Users could customize here and create a more sophisticated SinkRecord that includes:
+        // - key/value bytes
+        // - connector name
+        // - connector version
+        // etc.
+        DeadLetterTable.sinkRecord(sinkRecord, exception, DeadLetterTable.NAME),
+        // Users could customize here and make a dead-letter table per topic or whatever they want
+        DeadLetterTable.NAME);
+  }
+
+  @Override
+  public void preCommit() {}
+}

--- a/kafka-connect-exception-handlers/src/main/java/io/tabular/iceberg/connect/handler/KafkaDLQ.java
+++ b/kafka-connect-exception-handlers/src/main/java/io/tabular/iceberg/connect/handler/KafkaDLQ.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.handler;
+
+import io.tabular.iceberg.connect.IcebergSinkConfig;
+import io.tabular.iceberg.connect.WriteExceptionHandler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+
+/**
+ * Sends any record that can't be handled to Kafka.
+ *
+ * <p>Provides only at-least-once guarantees which is a limitation of the Kafka Connect {@link
+ * ErrantRecordReporter} API.
+ */
+class KafkaDLQ implements WriteExceptionHandler {
+  private SinkTaskContext context;
+
+  private List<Future<Void>> pendingFutures;
+
+  @SuppressWarnings("RegexpSingleline")
+  @Override
+  public void initialize(SinkTaskContext sinkTaskContext, IcebergSinkConfig config) {
+    this.context = sinkTaskContext;
+    this.pendingFutures = new ArrayList<>();
+  }
+
+  private boolean isDone(Future<Void> voidFuture) {
+    if (voidFuture.isDone()) {
+      try {
+        voidFuture.get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public Result handle(SinkRecord sinkRecord, String tableName, Exception exception) {
+    // TODO: I would much rather do something smarter with callbacks
+    //  but I only get the old java.util.concurrent.Future interface here >_<
+    pendingFutures.add(context.errantRecordReporter().report(sinkRecord, exception));
+    pendingFutures.removeIf(this::isDone);
+    return null;
+  }
+
+  @Override
+  public void preCommit() {
+    pendingFutures.forEach(
+        voidFuture -> {
+          try {
+            voidFuture.get();
+          } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+          }
+        });
+  }
+}

--- a/kafka-connect-exception-handlers/src/main/java/io/tabular/iceberg/connect/transform/ExceptionHandlingTransform.java
+++ b/kafka-connect-exception-handlers/src/main/java/io/tabular/iceberg/connect/transform/ExceptionHandlingTransform.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.transform;
+
+import io.tabular.iceberg.connect.DeadLetterTable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+/**
+ * This transform only works under the following conditions:
+ * <ol>
+ *  <li>Connector is configured with iceberg.tables.dynamic-enabled=true</li>
+ *  <li>Connector is configured with with a iceberg.tables.route-field=target_table</li>
+ *  <li>Connector is configured with key.converter=ByteArrayConverter</li>
+ *  <li>Connector is configured with value.converter=ByteArrayConverter</li>
+ *  <li>Connector is configured with header.converter=ByteArrayConverter</li>
+ * </ol>
+ */
+// TODO: bring in Lists and Maps classes library to get rid of SuppressWarning annotation
+@SuppressWarnings("RegexpSingleline")
+public class ExceptionHandlingTransform implements Transformation<SinkRecord> {
+
+  public static class PropsParser {
+    static Map<String, ?> apply(Map<String, ?> props, String target) {
+      return props.entrySet().stream()
+          .filter(
+              entry ->
+                  (!Objects.equals(entry.getKey(), target)) && (entry.getKey().startsWith(target)))
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().replaceFirst("^" + target + ".", ""),
+                  Map.Entry::getValue));
+    }
+  }
+
+  private static final String KEY_CONVERTER = "key.converter";
+  private static final String VALUE_CONVERTER = "value.converter";
+  private static final String HEADER_CONVERTER = "header.converter";
+  private static final String TRANSFORMATIONS = "SMTs";
+
+  private List<Transformation<SinkRecord>> smts;
+  private Converter keyConverter;
+  private Converter valueConverter;
+  private HeaderConverter headerConverter;
+
+  public static final ConfigDef CONFIG_DEF =
+      new ConfigDef()
+          .define(
+              KEY_CONVERTER,
+              ConfigDef.Type.STRING,
+              "org.apache.kafka.connect.converters.ByteArrayConverter",
+              ConfigDef.Importance.MEDIUM,
+              "The key.converter to use")
+          .define(
+              VALUE_CONVERTER,
+              ConfigDef.Type.STRING,
+              null,
+              ConfigDef.Importance.MEDIUM,
+              "The value.converter to use")
+          .define(
+              HEADER_CONVERTER,
+              ConfigDef.Type.STRING,
+              "org.apache.kafka.connect.converters.ByteArrayConverter",
+              ConfigDef.Importance.MEDIUM,
+              "The header.converter to use")
+          .define(
+              TRANSFORMATIONS,
+              ConfigDef.Type.STRING,
+              new ArrayList<>(),
+              ConfigDef.Importance.MEDIUM,
+              "The SMTs to apply");
+
+  @Override
+  public SinkRecord apply(SinkRecord originalRecord) {
+    try {
+      SinkRecord deserializedRecord = deserialize(originalRecord);
+      SinkRecord transformedRecord = transform(deserializedRecord);
+      return transformedRecord;
+    } catch (Exception exception) {
+      // Users could customize here and make a dead-letter table per topic or whatever they want
+      return DeadLetterTable.sinkRecord(originalRecord, exception, DeadLetterTable.NAME);
+    }
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  @Override
+  public void close() {
+    // TODO: humm close AutoCloseable converters and SMTs
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void configure(Map<String, ?> props) {
+    SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+    ClassLoader loader = this.getClass().getClassLoader();
+
+    keyConverter = (Converter) loadClass(config.getString(KEY_CONVERTER), loader);
+    keyConverter.configure(PropsParser.apply(props, KEY_CONVERTER), true);
+
+    valueConverter = (Converter) loadClass(config.getString(VALUE_CONVERTER), loader);
+    valueConverter.configure(PropsParser.apply(props, VALUE_CONVERTER), false);
+
+    headerConverter = (HeaderConverter) loadClass(config.getString(HEADER_CONVERTER), loader);
+    headerConverter.configure(PropsParser.apply(props, HEADER_CONVERTER));
+
+    smts =
+        Arrays.stream(config.getString(TRANSFORMATIONS).split(","))
+            .map(className -> loadClass(className, loader))
+            .map(obj -> (Transformation<SinkRecord>) obj)
+            .peek(smt -> smt.configure(PropsParser.apply(props, TRANSFORMATIONS)))
+            .collect(Collectors.toList());
+  }
+
+  private Object loadClass(String name, ClassLoader loader) {
+    if (name == null || name.isEmpty()) {
+      throw new RuntimeException("cannot initialize empty class");
+    }
+    Object obj;
+    try {
+      Class<?> clazz = Class.forName(name, true, loader);
+      obj = clazz.getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(String.format("Could not initialize class %s", name), e);
+    }
+    return obj;
+  }
+
+  private SinkRecord deserialize(SinkRecord originalRecord) {
+    String topic = originalRecord.topic();
+
+    RecordHeaders recordHeaders = new RecordHeaders();
+    for (Header header : originalRecord.headers()) {
+      recordHeaders.add(
+          header.key(),
+          headerConverter.fromConnectHeader(topic, header.key(), header.schema(), header.value()));
+    }
+
+    SchemaAndValue key =
+        keyConverter.toConnectData(topic, recordHeaders, (byte[]) originalRecord.key());
+
+    SchemaAndValue value =
+        valueConverter.toConnectData(topic, recordHeaders, (byte[]) originalRecord.value());
+
+    return originalRecord.newRecord(
+        topic,
+        originalRecord.kafkaPartition(),
+        key.schema(),
+        key.value(),
+        value.schema(),
+        value.value(),
+        originalRecord.timestamp(),
+        originalRecord.headers());
+  }
+
+  private SinkRecord transform(SinkRecord deserializedRecord) {
+    SinkRecord transformedRecord = deserializedRecord;
+    for (Transformation<SinkRecord> smt : smts) {
+      transformedRecord = smt.apply(deserializedRecord);
+    }
+    return transformedRecord;
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,6 @@ project(":iceberg-kafka-connect-transforms").projectDir = file("kafka-connect-tr
 
 include "iceberg-kafka-connect-runtime"
 project(":iceberg-kafka-connect-runtime").projectDir = file("kafka-connect-runtime")
+
+include "iceberg-kafka-connect-exception-handlers"
+project(":iceberg-kafka-connect-exception-handlers").projectDir = file("kafka-connect-exception-handlers")


### PR DESCRIPTION
It might be a little hard to see `WriteExceptionHandler` is all we really need to add to fit all the use cases. 
This PR should demonstrate how you should be able to fit the most common usecases within the `WriteExceptionHandler` framework. 

## I want to write out the original byte array to a dead-letter-table

In theory (i.e. NOT definitively proven yet) ...

For the usecase of writing out the original Kafka key/value byte arrays, we have to do a little bit of work: 
    - My idea here would be to write a Converter/SMT which preserves the original key/value byte arrays somewhere.
         - I'm thinking in the SinkRecord's key or the SinkRecord's headers or SinkRecords schemas parameters
    - This SinkRecord is passed to the `SinkTask.put` method
    - When an exception is thrown, our `WriteExceptionHandler.handle` method would pull out the key/value byte arrays from the SinkRecord's parameters/headers/key and return a new SinkRecord with those values
    - The connector would then write that new SinkRecord to the dead-letter table

Importantly, what I'm trying to avoid is having special record structure that the connector code needs to understand in order to do the right thing. The ideal situation for me is the connector is oblivious to "good" and "dead-letter-records-from-Converter/SMT-failures."

## I want to write out the original JSON to the dead-letter-table

Same approach as above

## I want to capture deserialization/SMT failures somehere!

Two options: 
- Use kafka-connect's built-in DLQ 
- Use dynamic-tables mode + an SMT that on error produces a SinkRecord destined for your dead-letter-table (see sample implementation in this PR)

## I want to capture null records somewhere!

Two options: 
- Use kafka-connect's built-in DLQ by throwing a NullRecordException :D 
- Use dynamic-tables mode + an SMT that for null records produces a SinkRecord destined for your null-records table

## I don't want to write bad records to Iceberg, I want to write to Kafka!

See KafkaDLQ for a sample implementation. 