### PR TITLE
fix-event-decoder-vtt

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/EventDecoder.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/EventDecoder.java
@@ -116,12 +116,12 @@ public class EventDecoder {
           pay.commitId(),
           TableReference.of(catalogName, pay.tableName().toIdentifier()),
           pay.snapshotId(),
-          OffsetDateTime.ofInstant(Instant.ofEpochMilli(pay.vtts()), ZoneOffset.UTC));
+          pay.vtts() == null ? null : OffsetDateTime.ofInstant(Instant.ofEpochMilli(pay.vtts()), ZoneOffset.UTC));
     } else if (payload instanceof CommitCompletePayload) {
       CommitCompletePayload pay = (CommitCompletePayload) payload;
       return new CommitComplete(
           pay.commitId(),
-          OffsetDateTime.ofInstant(Instant.ofEpochMilli(pay.vtts()), ZoneOffset.UTC));
+          pay.vtts() == null ? null : OffsetDateTime.ofInstant(Instant.ofEpochMilli(pay.vtts()), ZoneOffset.UTC));
     } else {
       throw new IllegalStateException(
           String.format("Unknown event payload: %s", payload.getSchema()));

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
@@ -259,6 +259,8 @@ public class EventDecoderTest {
     assertThat(payload.commitId()).isEqualTo(commitId);
     assertThat(payload.snapshotId()).isEqualTo(1L);
     assertThat(payload.validThroughTs()).isNull();
+    assertThat(payload.tableReference().catalog()).isEqualTo(catalogName);
+    assertThat(payload.tableReference().identifier()).isEqualTo(TableIdentifier.of("db", "tbl"));
   }
 
   @Test
@@ -290,6 +292,7 @@ public class EventDecoderTest {
     assertThat(result.type()).isEqualTo(PayloadType.COMMIT_COMPLETE);
     assertThat(result.payload()).isInstanceOf(CommitComplete.class);
     CommitComplete payload = (CommitComplete) result.payload();
+    assertThat(payload.commitId()).isEqualTo(commitId);
     assertThat(payload.validThroughTs()).isNull();
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
@@ -240,6 +240,28 @@ public class EventDecoderTest {
   }
 
   @Test
+  public void testCommitTableBecomesCommitToTableNullVtts() {
+    io.tabular.iceberg.connect.events.Event event =
+            new io.tabular.iceberg.connect.events.Event(
+                    "cg-connector",
+                    EventType.COMMIT_TABLE,
+                    new CommitTablePayload(
+                            commitId, new TableName(Collections.singletonList("db"), "tbl"), 1L, null));
+
+    byte[] data = io.tabular.iceberg.connect.events.Event.encode(event);
+
+    Event result = eventDecoder.decode(data);
+    assertThat(event.groupId()).isEqualTo("cg-connector");
+    assertThat(result.type()).isEqualTo(PayloadType.COMMIT_TO_TABLE);
+    assertThat(result.payload()).isInstanceOf(CommitToTable.class);
+    CommitToTable payload = (CommitToTable) result.payload();
+
+    assertThat(payload.commitId()).isEqualTo(commitId);
+    assertThat(payload.snapshotId()).isEqualTo(1L);
+    assertThat(payload.validThroughTs()).isNull();
+  }
+
+  @Test
   public void testCommitCompleteBecomesCommitCompleteSerialization() {
     io.tabular.iceberg.connect.events.Event event =
         new io.tabular.iceberg.connect.events.Event(
@@ -254,5 +276,20 @@ public class EventDecoderTest {
     assertThat(payload.commitId()).isEqualTo(commitId);
     assertThat(payload.validThroughTs())
         .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(2L), ZoneOffset.UTC));
+  }
+
+  @Test
+  public void testCommitCompleteBecomesCommitCompleteSerializationNullVtts() {
+    io.tabular.iceberg.connect.events.Event event =
+            new io.tabular.iceberg.connect.events.Event(
+                    "cg-connector", EventType.COMMIT_COMPLETE, new CommitCompletePayload(commitId, null));
+
+    byte[] data = io.tabular.iceberg.connect.events.Event.encode(event);
+
+    Event result = eventDecoder.decode(data);
+    assertThat(result.type()).isEqualTo(PayloadType.COMMIT_COMPLETE);
+    assertThat(result.payload()).isInstanceOf(CommitComplete.class);
+    CommitComplete payload = (CommitComplete) result.payload();
+    assertThat(payload.validThroughTs()).isNull();
   }
 }


### PR DESCRIPTION
- two null checks were missed when converting old records that can have null values for valid through timestamps

```
│       Trace:  java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "io.tabular.iceberg.connect.events.CommitTablePayload.vtts()" is null                        │
│               at io.tabular.iceberg.connect.channel.EventDecoder.convertPayload(EventDecoder.java:119)                                                                                                            │
│               at io.tabular.iceberg.connect.channel.EventDecoder.convertLegacy(EventDecoder.java:82)                                                                                                              │
│               at io.tabular.iceberg.connect.channel.EventDecoder.decode(EventDecoder.java:77)                                                                                                                     │
│               at io.tabular.iceberg.connect.channel.Channel.lambda$consumeAvailable$2(Channel.java:131)                                                                                                           │
│               at java.base/java.lang.Iterable.forEach(Iterable.java:75)                                                                                                                                           │
│               at io.tabular.iceberg.connect.channel.Channel.consumeAvailable(Channel.java:125)        
```
