### PR TITLE
docs(README): update control topic part

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The zip archive will be found under `./kafka-connect-runtime/build/distributions
 | iceberg.table.\<table name\>.id-columns    | Comma-separated list of columns that identify a row in the table (primary key)                                   |
 | iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                          |
 | iceberg.table.\<table name\>.route-regex   | The regex used to match a record's `routeField` to a table                                                       |
-| iceberg.control.topic                      | Name of the control topic, default is `control-iceberg`                                                          |
+| iceberg.control.topic                      | Name of the control topic, default is `control-iceberg`.
+The same control topic cannot be used for different connectors consuming from different topics.                                                                 |
 | iceberg.control.group-id                   | Name of the consumer group to store offsets, default is `cg-control-<connector name>`                            |
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |


### PR DESCRIPTION
This PR is related to issue #247.

Using the same control topic for multiple connectors that consume from different topics can lead to unexpected behavior.
In my experience, we had over 20 connectors sinking data from more than 20 topics, all sharing the same control topic, which caused the issues described in #247.