### PR TITLE
Make connect compatable with kafka plugin.discovery

### DIFF
--- a/kafka-connect-transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/kafka-connect-transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -1,0 +1,4 @@
+io.tabular.iceberg.connect.transforms.DebeziumTransform
+io.tabular.iceberg.connect.transforms.JsonToMapTransform
+io.tabular.iceberg.connect.transforms.KafkaMetadataTransform
+io.tabular.iceberg.connect.transforms.MongoDebeziumTransform

--- a/kafka-connect/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/kafka-connect/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,1 @@
+io.tabular.iceberg.connect.IcebergSinkConnector


### PR DESCRIPTION
What is [Plugin Discovery](https://kafka.apache.org/documentation.html#connect_plugindiscovery).

When connector is used with kafka version above 3.6 with default plugin.discovery worker configuration there would be a warning

```
org.apache.kafka.connect.runtime.isolation.Plugins","message":"One or more plugins are missing ServiceLoader manifests may not be usable with plugin.discovery=service_load: [
...
Read the documentation at https://kafka.apache.org/documentation.html#connect_plugindiscovery for instructions on migrating your plugins to take advantage of the performance improvements of service_load mode. To silence this warning, set plugin.discovery=only_scan in the worker config.
```