### PR TITLE
Improve initial connection timeouts with Amazon MSK clusters

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
@@ -49,6 +49,9 @@ public abstract class Channel {
 
   private static final Logger LOG = LoggerFactory.getLogger(Channel.class);
 
+  // 30 seconds set as minimum for Amazon MSK to connect successfully
+  protected static final int INITIAL_CONNECTION_TIMEOUT_MS = 30000;
+
   private final String controlTopic;
   private final String groupId;
   private final Producer<String, byte[]> producer;

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
@@ -100,7 +100,7 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
 
     consumeAvailable(
         // initial poll with longer duration so the consumer will initialize...
-        Duration.ofMillis(1000),
+        Duration.ofMillis(INITIAL_CONNECTION_TIMEOUT_MS),
         envelope ->
             receive(
                 envelope,

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -90,7 +90,7 @@ public class Coordinator extends Channel implements AutoCloseable {
     this.commitState = new CommitState(config);
 
     // initial poll with longer duration so the consumer will initialize...
-    consumeAvailable(Duration.ofMillis(1000), this::receive);
+    consumeAvailable(Duration.ofMillis(INITIAL_CONNECTION_TIMEOUT_MS), this::receive);
   }
 
   public void process() {


### PR DESCRIPTION
This PR solves the issue of the control topics not being able to join successfully on a cloud environment as the current timeout is set to 1 second and it's not enough.

Before this PR: `cg-control-XXX` consumers are not always joining on time and the connector fails
After this PR: new timeout allows consumers join the consumer group and sink connectors work without issues

How to reproduce the issue?
1. Create an AWS MSK cluster with 1 topic (a local cluster is not valid as it's local network and it will surely work)
2. Install kafka-ui or any tool to check consumers of the topic
3. Create an Iceberg connector through MSK Connect
4. Check logs in Cloudwatch or the enabled logs tool when creating the connector
5. Post a message after initialisation
6. Check if the message is consumed (logs) and saved in your target system

Note: The connector will be marked as `Running` on MSK even if it couldn't start properly with the result of not consuming messages. 