### PR TITLE
remove ListConsumerGroupOffsetsOptions for backward compatibility on older connect versions

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
@@ -112,8 +112,7 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
     try {
       ListConsumerGroupOffsetsResult response =
           admin()
-              .listConsumerGroupOffsets(
-                  groupId, new ListConsumerGroupOffsetsOptions().requireStable(true));
+              .listConsumerGroupOffsets(groupId);
       return response.partitionsToOffsetAndMetadata().get().entrySet().stream()
           .filter(entry -> context.assignment().contains(entry.getKey()))
           .collect(toMap(Map.Entry::getKey, entry -> entry.getValue().offset()));


### PR DESCRIPTION
This is a partial fix to #273.

The connector uses transactional producers and I think this call is not needed, as stable offsets are available after producer commit. It is also breaking on earlier versions of connect.

I'm not certain if this is the proper fix, but appreciate if any maintaners of the repo/connector would take a look, so opening a PR to put things into motion 👍🏾 😄 