### PR TITLE
Enable zombie-fencing with using integrated connect consumer group

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -99,6 +99,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String DEFAULT_CATALOG_NAME = "iceberg";
   private static final String DEFAULT_CONTROL_TOPIC = "control-iceberg";
   public static final String DEFAULT_CONTROL_GROUP_PREFIX = "cg-control-";
+  public static final String DEFAULT_COORDINATOR_CONTROL_GROUP_SUFFIX = "-coord";
 
   public static final int SCHEMA_UPDATE_RETRIES = 2; // 3 total attempts
   public static final int CREATE_TABLE_RETRIES = 2; // 3 total attempts
@@ -388,6 +389,16 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public String controlTopic() {
     return getString(CONTROL_TOPIC_PROP);
+  }
+
+  public String controlCoordinatorGroupId() {
+    String result = getString(CONTROL_GROUP_ID_PROP);
+    if (result != null) {
+      return result + DEFAULT_COORDINATOR_CONTROL_GROUP_SUFFIX;
+    }
+    String connectorName = connectorName();
+    Preconditions.checkNotNull(connectorName, "Connector name cannot be null");
+    return DEFAULT_CONTROL_GROUP_PREFIX + connectorName + DEFAULT_COORDINATOR_CONTROL_GROUP_SUFFIX;
   }
 
   public String connectGroupId() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -390,16 +390,6 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getString(CONTROL_TOPIC_PROP);
   }
 
-  public String controlGroupId() {
-    String result = getString(CONTROL_GROUP_ID_PROP);
-    if (result != null) {
-      return result;
-    }
-    String connectorName = connectorName();
-    Preconditions.checkNotNull(connectorName, "Connector name cannot be null");
-    return DEFAULT_CONTROL_GROUP_PREFIX + connectorName;
-  }
-
   public String connectGroupId() {
     String result = getString(CONNECT_GROUP_ID_PROP);
     if (result != null) {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
@@ -50,7 +50,7 @@ public abstract class Channel {
   private static final Logger LOG = LoggerFactory.getLogger(Channel.class);
 
   private final String controlTopic;
-  private final String groupId;
+  private final String connectGroupId;
   private final Producer<String, byte[]> producer;
   private final Consumer<String, byte[]> consumer;
   private final Admin admin;
@@ -65,7 +65,7 @@ public abstract class Channel {
       IcebergSinkConfig config,
       KafkaClientFactory clientFactory) {
     this.controlTopic = config.controlTopic();
-    this.groupId = config.controlGroupId();
+    this.connectGroupId = config.connectGroupId();
 
     String transactionalId = name + config.transactionalSuffix();
     Pair<UUID, Producer<String, byte[]>> pair = clientFactory.createProducer(transactionalId);
@@ -130,7 +130,7 @@ public abstract class Channel {
 
             Event event = eventDecoder.decode(record.value());
             if (event != null) {
-              if (event.groupId().equals(groupId)) {
+              if (event.groupId().equals(connectGroupId)) {
                 LOG.debug("Received event of type: {}", event.type().name());
                 if (receiveFn.apply(new Envelope(event, record.partition(), record.offset()))) {
                   LOG.debug("Handled event of type: {}", event.type().name());

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -78,7 +78,7 @@ public class Coordinator extends Channel implements AutoCloseable {
       Collection<MemberDescription> members,
       KafkaClientFactory clientFactory) {
     // pass consumer group ID to which we commit low watermark offsets
-    super("coordinator", config.connectGroupId() + "-coord", config, clientFactory);
+    super("coordinator", config.controlCoordinatorGroupId(), config, clientFactory);
 
     this.catalog = catalog;
     this.config = config;

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/KafkaUtils.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/KafkaUtils.java
@@ -19,13 +19,20 @@
 package io.tabular.iceberg.connect.channel;
 
 import java.util.concurrent.ExecutionException;
+import org.apache.iceberg.common.DynFields;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 
 public class KafkaUtils {
+
+  private static final String CONTEXT_CLASS_NAME =
+          "org.apache.kafka.connect.runtime.WorkerSinkTaskContext";
 
   public static ConsumerGroupDescription consumerGroupDescription(
       String consumerGroupId, Admin admin) {
@@ -38,6 +45,17 @@ public class KafkaUtils {
       throw new ConnectException(
           "Cannot retrieve members for consumer group: " + consumerGroupId, e);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  public static ConsumerGroupMetadata getConsumerGroupMetadata(
+          SinkTaskContext context, String connectGroupId) {
+    if (CONTEXT_CLASS_NAME.equals(context.getClass().getName())) {
+      return ((Consumer<byte[], byte[]>)
+              DynFields.builder().hiddenImpl(CONTEXT_CLASS_NAME, "consumer").build(context).get())
+              .groupMetadata();
+    }
+    return new ConsumerGroupMetadata(connectGroupId);
   }
 
   private KafkaUtils() {}

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/ChannelTestBase.java
@@ -56,7 +56,7 @@ public class ChannelTestBase {
   protected static final String SRC_TOPIC_NAME = "src-topic";
   protected static final String CTL_TOPIC_NAME = "ctl-topic";
   protected static final TopicPartition CTL_TOPIC_PARTITION = new TopicPartition(CTL_TOPIC_NAME, 0);
-  protected static final String CONTROL_CONSUMER_GROUP_ID = "cg-connector";
+  protected static final String CONNECT_CONSUMER_GROUP_ID = "cg-connector";
   protected InMemoryCatalog catalog;
   protected Table table;
   protected IcebergSinkConfig config;
@@ -84,7 +84,7 @@ public class ChannelTestBase {
 
   protected static final String COMMIT_ID_SNAPSHOT_PROP = "kafka.connect.commit-id";
   protected static final String OFFSETS_SNAPSHOT_PROP =
-      String.format("kafka.connect.offsets.%s.%s", CTL_TOPIC_NAME, CONTROL_CONSUMER_GROUP_ID);
+      String.format("kafka.connect.offsets.%s.%s", CTL_TOPIC_NAME, CONNECT_CONSUMER_GROUP_ID);
   protected static final String VTTS_SNAPSHOT_PROP = "kafka.connect.vtts";
 
   @BeforeEach
@@ -97,7 +97,7 @@ public class ChannelTestBase {
     config = mock(IcebergSinkConfig.class);
     when(config.controlTopic()).thenReturn(CTL_TOPIC_NAME);
     when(config.commitThreads()).thenReturn(1);
-    when(config.controlGroupId()).thenReturn(CONTROL_CONSUMER_GROUP_ID);
+    when(config.connectGroupId()).thenReturn(CONNECT_CONSUMER_GROUP_ID);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
     when(config.catalogName()).thenReturn("catalog");
 

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitterImplTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitterImplTest.java
@@ -300,7 +300,7 @@ class CommitterImplTest {
 
     whenAdminListConsumerGroupOffsetsThenReturn(
         ImmutableMap.of(
-            config.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L),
+            config.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L),
             config.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 90L, SOURCE_TP1, 80L)));
 
     try (CommitterImpl ignored =
@@ -320,7 +320,7 @@ class CommitterImplTest {
 
     whenAdminListConsumerGroupOffsetsThenReturn(
         ImmutableMap.of(
-            config.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            CONFIG.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
     TerminatedCoordinatorThreadFactory coordinatorThreadFactory =
         new TerminatedCoordinatorThreadFactory();
@@ -352,7 +352,7 @@ class CommitterImplTest {
 
     whenAdminListConsumerGroupOffsetsThenReturn(
         ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            CONFIG.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
     CommittableSupplier committableSupplier =
         () -> {
@@ -379,7 +379,7 @@ class CommitterImplTest {
 
     whenAdminListConsumerGroupOffsetsThenReturn(
         ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            CONFIG.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
     CommittableSupplier committableSupplier =
         () -> {
@@ -399,7 +399,7 @@ class CommitterImplTest {
               UUID.randomUUID().toString(),
               AvroUtil.encode(
                   new Event(
-                      CONFIG.controlGroupId(),
+                      CONFIG.connectGroupId(),
                       new CommitComplete(UUID.randomUUID(), offsetDateTime(100L))))));
 
       committer.commit(committableSupplier);
@@ -418,7 +418,7 @@ class CommitterImplTest {
 
     whenAdminListConsumerGroupOffsetsThenReturn(
         ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            CONFIG.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
     List<DataFile> dataFiles = ImmutableList.of(createDataFile());
     List<DeleteFile> deleteFiles = ImmutableList.of();
@@ -444,7 +444,7 @@ class CommitterImplTest {
               UUID.randomUUID().toString(),
               AvroUtil.encode(
                   new Event(
-                      CONFIG.controlGroupId(),
+                      CONFIG.connectGroupId(),
                       new StartCommit(commitId)))));
 
       committer.commit(committableSupplier);
@@ -468,7 +468,7 @@ class CommitterImplTest {
       Map<TopicPartition, OffsetAndMetadata> expectedConsumerOffset =
           ImmutableMap.of(SOURCE_TP0, new OffsetAndMetadata(100L));
       assertThat(producer.consumerGroupOffsetsHistory().get(0))
-          .isEqualTo(ImmutableMap.of(CONFIG.controlGroupId(), expectedConsumerOffset));
+          .isEqualTo(ImmutableMap.of(CONFIG.connectGroupId(), expectedConsumerOffset));
       assertThat(producer.consumerGroupOffsetsHistory().get(1))
           .isEqualTo(ImmutableMap.of(CONFIG.connectGroupId(), expectedConsumerOffset));
     }
@@ -484,7 +484,7 @@ class CommitterImplTest {
 
     whenAdminListConsumerGroupOffsetsThenReturn(
         ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            CONFIG.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
     CommittableSupplier committableSupplier =
         () -> new Committable(ImmutableMap.of(), ImmutableList.of());
@@ -502,7 +502,7 @@ class CommitterImplTest {
               UUID.randomUUID().toString(),
               AvroUtil.encode(
                   new Event(
-                      CONFIG.controlGroupId(),
+                      CONFIG.connectGroupId(),
                       new StartCommit(commitId)))));
 
 
@@ -536,7 +536,7 @@ class CommitterImplTest {
 
     whenAdminListConsumerGroupOffsetsThenReturn(
         ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            CONFIG.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
     List<DataFile> dataFiles = ImmutableList.of(createDataFile());
     List<DeleteFile> deleteFiles = ImmutableList.of();
@@ -561,7 +561,7 @@ class CommitterImplTest {
               UUID.randomUUID().toString(),
               AvroUtil.encode(
                   new Event(
-                      CONFIG.controlGroupId(),
+                      CONFIG.connectGroupId(),
                       new StartCommit(commitId)))));
 
       committer.commit(committableSupplier);
@@ -587,7 +587,7 @@ class CommitterImplTest {
       Map<TopicPartition, OffsetAndMetadata> expectedConsumerOffset =
           ImmutableMap.of(sourceTp1, new OffsetAndMetadata(100L));
       assertThat(producer.consumerGroupOffsetsHistory().get(0))
-          .isEqualTo(ImmutableMap.of(CONFIG.controlGroupId(), expectedConsumerOffset));
+          .isEqualTo(ImmutableMap.of(CONFIG.connectGroupId(), expectedConsumerOffset));
       assertThat(producer.consumerGroupOffsetsHistory().get(1))
           .isEqualTo(ImmutableMap.of(CONFIG.connectGroupId(), expectedConsumerOffset));
     }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -176,7 +176,7 @@ public class CoordinatorTest extends ChannelTestBase {
             currentCommitId -> {
               Event commitResponse =
                   new Event(
-                      config.controlGroupId(),
+                      config.connectGroupId(),
                       new DataWritten(
                           StructType.of(),
                           currentCommitId,
@@ -188,7 +188,7 @@ public class CoordinatorTest extends ChannelTestBase {
                   commitResponse,
                   commitResponse, // duplicate commit response
                   new Event(
-                      config.controlGroupId(),
+                      config.connectGroupId(),
                       new DataComplete(
                           currentCommitId,
                           ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)))));
@@ -216,7 +216,7 @@ public class CoordinatorTest extends ChannelTestBase {
             currentCommitId -> {
               Event duplicateCommitResponse =
                   new Event(
-                      config.controlGroupId(),
+                      config.connectGroupId(),
                       new DataWritten(
                           StructType.of(),
                           currentCommitId,
@@ -228,7 +228,7 @@ public class CoordinatorTest extends ChannelTestBase {
                   duplicateCommitResponse,
                   duplicateCommitResponse, // duplicate commit response
                   new Event(
-                      config.controlGroupId(),
+                      config.connectGroupId(),
                       new DataComplete(
                           currentCommitId,
                           ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)))));
@@ -338,7 +338,7 @@ public class CoordinatorTest extends ChannelTestBase {
               "key",
               AvroUtil.encode(
                   new Event(
-                      config.controlGroupId(),
+                      config.connectGroupId(),
                       new DataWritten(
                           spec.partitionType(),
                           commitId,
@@ -355,7 +355,7 @@ public class CoordinatorTest extends ChannelTestBase {
               "key",
               AvroUtil.encode(
                   new Event(
-                      config.controlGroupId(),
+                      config.connectGroupId(),
                       new DataComplete(
                           commitId,
                           ImmutableList.of(
@@ -433,7 +433,7 @@ public class CoordinatorTest extends ChannelTestBase {
         currentCommitId -> {
           Event commitResponse =
               new Event(
-                  config.controlGroupId(),
+                  config.connectGroupId(),
                   new DataWritten(
                       StructType.of(),
                       currentCommitId,
@@ -443,7 +443,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
           Event commitReady =
               new Event(
-                  config.controlGroupId(),
+                  config.connectGroupId(),
                   new DataComplete(
                       currentCommitId,
                       ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts))));


### PR DESCRIPTION
## Contents
- Apply the commit from closed PR(https://github.com/tabular-io/iceberg-kafka-connect/pull/240) to enable zombie-fencing
- The test code requires further improvement to align with these changes, but for now, it has been modified to pass.

## Related Links
- https://github.com/tabular-io/iceberg-kafka-connect/pull/280
- https://apache-iceberg.slack.com/archives/C03SEK9PW0Z/p1721977110612699