### PR TITLE
add checkClassName regex func

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/IcebergSinkConfig.java
@@ -451,12 +451,15 @@ public class IcebergSinkConfig extends AbstractConfig {
     return jsonConverter;
   }
 
+  public static boolean checkClassName(String className) {
+    return (className.matches(".*\\.ConnectDistributed.*") || className.matches(".*\\.ConnectStandalone.*"));
+  }
+
   private Map<String, String> loadWorkerProps() {
     String javaCmd = System.getProperty("sun.java.command");
     if (javaCmd != null && !javaCmd.isEmpty()) {
       String[] args = javaCmd.split(" ");
-      if (args.length > 1
-          && (args[0].endsWith(".ConnectDistributed") || args[0].endsWith(".ConnectStandalone"))) {
+      if (args.length > 1 && checkClassName(args[0])) {
         Properties result = new Properties();
         try (InputStream in = Files.newInputStream(Paths.get(args[1]))) {
           result.load(in);

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/IcebergSinkConfigTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/IcebergSinkConfigTest.java
@@ -88,4 +88,25 @@ public class IcebergSinkConfigTest {
 
   @Test
   public void testStringWithParensToList() {}
+
+  @Test
+  public void testCheckClassName() {
+    Boolean result = IcebergSinkConfig.checkClassName("org.apache.kafka.connect.cli.ConnectDistributed");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("org.apache.kafka.connect.cli.ConnectStandalone");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("some.other.package.ConnectDistributed");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("some.other.package.ConnectStandalone");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("some.package.ConnectDistributedWrapper");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("org.apache.kafka.clients.producer.KafkaProducer");
+    assertThat(result).isFalse();
+  }
 }


### PR DESCRIPTION
We have a custom wrapper on the ConnectDistributed class which does not match the regex check here. This PR expands the regex to be more generous but is still reasonable.
Closes #301