### PR TITLE
Convert Insert to Update when CDC enabled and upsertMode enabled

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/BaseDeltaTaskWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/BaseDeltaTaskWriter.java
@@ -70,10 +70,13 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
 
   @Override
   public void write(Record row) throws IOException {
-    Operation op =
-        row instanceof RecordWrapper
-            ? ((RecordWrapper) row).op()
-            : upsertMode ? Operation.UPDATE : Operation.INSERT;
+    Operation op = Operation.INSERT;
+    if (row instanceof RecordWrapper) {
+      op = ((RecordWrapper) row).op();
+    }
+    if (upsertMode && op == Operation.INSERT) {
+      op = Operation.UPDATE;
+    }
     RowDataDeltaWriter writer = route(row);
     if (op == Operation.UPDATE || op == Operation.DELETE) {
       writer.deleteKey(keyProjection.wrap(row));

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriterTest.java
@@ -67,4 +67,38 @@ public class PartitionedDeltaWriterTest extends BaseWriterTest {
     assertThat(result.deleteFiles())
         .allMatch(file -> file.format() == FileFormat.fromString(format));
   }
+  
+  @ParameterizedTest
+  @ValueSource(strings = {"parquet", "orc"})
+  public void testPartitionedDeltaWriterCDC(String format) {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.upsertModeEnabled()).thenReturn(true);
+    when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.writeProps()).thenReturn(ImmutableMap.of("write.format.default", format));
+
+    when(table.spec()).thenReturn(SPEC);
+
+    Record row1 = GenericRecord.create(SCHEMA);
+    row1.setField("id", 123L);
+    row1.setField("data", "hello world!");
+    row1.setField("id2", 123L);
+    row1 = new RecordWrapper(row1, Operation.INSERT);
+
+    Record row2 = GenericRecord.create(SCHEMA);
+    row2.setField("id", 234L);
+    row2.setField("data", "foobar");
+    row2.setField("id2", 234L);
+    row2 = new RecordWrapper(row2, Operation.INSERT);
+
+    WriteResult result =
+        writeTest(ImmutableList.of(row1, row2), config, PartitionedDeltaWriter.class);
+
+    // in upsert mode, each write is a delete + append, so we'll have 1 data file
+    // and 1 delete file for each partition (2 total)
+    assertThat(result.dataFiles()).hasSize(2);
+    assertThat(result.dataFiles()).allMatch(file -> file.format() == FileFormat.fromString(format));
+    assertThat(result.deleteFiles()).hasSize(2);
+    assertThat(result.deleteFiles())
+        .allMatch(file -> file.format() == FileFormat.fromString(format));
+  }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/PartitionedDeltaWriterTest.java
@@ -67,7 +67,7 @@ public class PartitionedDeltaWriterTest extends BaseWriterTest {
     assertThat(result.deleteFiles())
         .allMatch(file -> file.format() == FileFormat.fromString(format));
   }
-  
+
   @ParameterizedTest
   @ValueSource(strings = {"parquet", "orc"})
   public void testPartitionedDeltaWriterCDC(String format) {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UnpartitionedDeltaWriterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UnpartitionedDeltaWriterTest.java
@@ -59,7 +59,7 @@ public class UnpartitionedDeltaWriterTest extends BaseWriterTest {
     assertThat(result.deleteFiles())
         .allMatch(file -> file.format() == FileFormat.fromString(format));
   }
-  
+
   @ParameterizedTest
   @ValueSource(strings = {"parquet", "orc"})
   public void testUnpartitionedDeltaWriterCDC(String format) {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UnpartitionedDeltaWriterTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UnpartitionedDeltaWriterTest.java
@@ -59,4 +59,29 @@ public class UnpartitionedDeltaWriterTest extends BaseWriterTest {
     assertThat(result.deleteFiles())
         .allMatch(file -> file.format() == FileFormat.fromString(format));
   }
+  
+  @ParameterizedTest
+  @ValueSource(strings = {"parquet", "orc"})
+  public void testUnpartitionedDeltaWriterCDC(String format) {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.upsertModeEnabled()).thenReturn(true);
+    when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.writeProps()).thenReturn(ImmutableMap.of("write.format.default", format));
+
+    Record row = GenericRecord.create(SCHEMA);
+    row.setField("id", 123L);
+    row.setField("data", "hello world!");
+    row.setField("id2", 123L);
+    row = new RecordWrapper(row, Operation.INSERT);
+
+    WriteResult result = writeTest(ImmutableList.of(row), config, UnpartitionedDeltaWriter.class);
+
+    // in upsert mode, each write is a delete + append, so we'll have 1 data file
+    // and 1 delete file
+    assertThat(result.dataFiles()).hasSize(1);
+    assertThat(result.dataFiles()).allMatch(file -> file.format() == FileFormat.fromString(format));
+    assertThat(result.deleteFiles()).hasSize(1);
+    assertThat(result.deleteFiles())
+        .allMatch(file -> file.format() == FileFormat.fromString(format));
+  }
 }


### PR DESCRIPTION
I believe this fixes: https://github.com/databricks/iceberg-kafka-connect/issues/318 and https://github.com/databricks/iceberg-kafka-connect/issues/291